### PR TITLE
Refine check for item link in Head.php

### DIFF
--- a/lib/MBMigration/Builder/Layout/Theme/Anthem/Elements/Head.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Anthem/Elements/Head.php
@@ -157,7 +157,7 @@ class Head extends Element
                 $imageLogo['imageWidth'] = $item['settings']['image']['width'];
                 $imageLogo['imageHeight'] = $item['settings']['image']['height'];
 
-                if ($item['link'] != '') {
+                if (isset($item['link']) && $item['link'] !== '') {
                     $imageLogo['link'] = $item['link'];
                 } else {
                     $imageLogo['link'] = $this->cache->get('ParentPages')[0]['slug'];


### PR DESCRIPTION
This update includes a more comprehensive evaluation of the 'link' element in items for Theme/Anthem. Now, it not only checks whether the link field is non-empty, but also validates its existence before performing a check. This prevents potential undefined index issues.