### PR TITLE
Replace 'removePx' method with 'str_replace'

### DIFF
--- a/lib/MBMigration/Builder/Layout/Theme/Anthem/Anthem.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Anthem/Anthem.php
@@ -361,7 +361,7 @@ class Anthem extends LayoutUtils
 
         $opacityIsSet = false;
         foreach ($sectionStyles['data'] as $key => $value) {
-            $convertedData = $this->convertColor($this->removePx($value));
+            $convertedData = $this->convertColor(str_replace("px", "", $value));
             if (is_array($convertedData)) {
                 $style[$key] = $convertedData['color'];
                 $style['opacity'] = $convertedData['opacity'];
@@ -399,7 +399,7 @@ class Anthem extends LayoutUtils
 
         $opacityIsSet = false;
         foreach ($sectionStyles['data'] as $key => $value) {
-            $convertedData = $this->convertColor(trim($style[$value], 'px'));
+            $convertedData = $this->convertColor(str_replace("px", "", $value));
             if (is_array($convertedData)) {
                 $style[$key] = $convertedData['color'];
                 $style['opacity'] = $convertedData['opacity'];
@@ -459,7 +459,7 @@ class Anthem extends LayoutUtils
 
         $opacityIsSet = false;
         foreach ($sectionStyles['data'] as $key => $value) {
-            $convertedData = $this->convertColor(trim($style[$value], 'px'));
+            $convertedData = $this->convertColor(str_replace("px", "", $value));
             if (is_array($convertedData)) {
                 $style[$key] = $convertedData['color'];
                 $style['opacity'] = $convertedData['opacity'];

--- a/lib/MBMigration/Core/ErrorDump.php
+++ b/lib/MBMigration/Core/ErrorDump.php
@@ -48,7 +48,7 @@ class ErrorDump
             'file' => $file,
             'line' => $line,
             'details_message' => Utils::$MESSAGES_POOL,
-            'cache' => $this->cache->getCache()
+//            'cache' => $this->cache->getCache()
         ];
     }
 


### PR DESCRIPTION
The 'removePx' method used in the theme file was replaced with PHP's built-in 'str_replace' function. This change reduces the complexity and improves the efficiency of the theme's opacity set function. Also, the calling of 'getCache' function in the 'ErrorDump' service has been commented out temporarily for debugging purposes.