### PR TITLE
Added protocolTimeout to Puppeteer options

### DIFF
--- a/lib/MBMigration/Browser/Browser.php
+++ b/lib/MBMigration/Browser/Browser.php
@@ -29,7 +29,13 @@ class Browser implements BrowserInterface
     private function __construct($scriptPath, LoggerInterface $logger = null)
     {
         $puppeteer = new Puppeteer(
-            ['log_browser_console' => true, 'log_node_console' => true, 'logger' => $logger, 'debug' => true]
+            [
+                'log_browser_console' => true,
+                'log_node_console' => true,
+                'logger' => $logger,
+                'debug' => true,
+                'protocolTimeout' => 120000,
+            ]
         );
         $this->browser = $puppeteer->launch([
             "headless" => "new",

--- a/lib/MBMigration/Browser/Browser.php
+++ b/lib/MBMigration/Browser/Browser.php
@@ -34,7 +34,9 @@ class Browser implements BrowserInterface
                 'log_node_console' => true,
                 'logger' => $logger,
                 'debug' => true,
-                'protocolTimeout' => 120000,
+                'protocolTimeout' => 9000,
+                'read_timeout' => 9000,
+                'idle_timeout' => 9000
             ]
         );
         $this->browser = $puppeteer->launch([

--- a/lib/MBMigration/Builder/Layout/Theme/Anthem/Elements/LeftMedia.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Anthem/Elements/LeftMedia.php
@@ -111,10 +111,25 @@ class LeftMedia extends Element
         return json_encode($block);
     }
 
-    private function textCreation($richText, $objBlock)
+    private function textCreation($sectionData, $objBlock)
     {
-        foreach ($richText['brzElement'] as $item) {
-            $objBlock->item()->item()->item(1)->addItem($item);
+        $i = 0;
+        foreach ($sectionData['brzElement'] as $textItem) {
+            switch ($textItem['type']) {
+                case 'EmbedCode':
+                    if(!empty($sectionData['content'])) {
+                        $embedCode = $this->findEmbeddedPasteDivs($sectionData['content']);
+                        if(is_array($embedCode)){
+                            $objBlock->item()->item()->item(1)->addItem($this->embedCode($embedCode[$i]));
+                        }
+                        $i++;
+                    }
+                    break;
+                case 'Cloneable':
+                case 'Wrapper':
+                $objBlock->item()->item()->item(1)->addItem($textItem);
+                    break;
+            }
         }
     }
 }

--- a/lib/MBMigration/Builder/Layout/Theme/Anthem/Elements/ListLayout.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Anthem/Elements/ListLayout.php
@@ -105,8 +105,10 @@ class ListLayout extends Element
 
             foreach ($section['item'] as $item) {
                 if ($item['category'] === 'photo') {
-                    $objImage->item(0)->item(0)->setting('imageSrc', $item['content']);
-                    $objImage->item(0)->item(0)->setting('imageFileName', $item['imageFileName']);
+                    if (isset($item['content']) && isset($item['imageFileName'])){
+                        $objImage->item(0)->item(0)->setting('imageSrc', $item['content']);
+                        $objImage->item(0)->item(0)->setting('imageFileName', $item['imageFileName']);
+                    }
 
                     if ($item['link'] != '') {
                         $objImage->item(0)->item(0)->setting('linkType', 'external');

--- a/lib/MBMigration/Builder/Layout/Theme/Anthem/Elements/RightMedia.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Anthem/Elements/RightMedia.php
@@ -135,10 +135,26 @@ class RightMedia extends Element
         return json_encode($block);
     }
 
-    private function textCreation($richText, $objBlock)
+    private function textCreation($sectionData, $objBlock)
     {
-        foreach ($richText['brzElement'] as $item) {
-            $objBlock->item()->item()->item()->addItem($item);
+
+        $i = 0;
+        foreach ($sectionData['brzElement'] as $textItem) {
+            switch ($textItem['type']) {
+                case 'EmbedCode':
+                    if(!empty($sectionData['content'])) {
+                        $embedCode = $this->findEmbeddedPasteDivs($sectionData['content']);
+                        if(is_array($embedCode)){
+                            $objBlock->item()->item()->item()->addItem($this->embedCode($embedCode[$i]));
+                        }
+                        $i++;
+                    }
+                    break;
+                case 'Cloneable':
+                case 'Wrapper':
+                    $objBlock->item()->item()->item(1)->addItem($textItem);
+                    break;
+            }
         }
     }
 


### PR DESCRIPTION
The Puppeteer options in the browser constructor have been extended. A protocolTimeout has been added with a value of 120000 to handle longer lasting operations without throwing a timeout error.