### PR TITLE
Refactor and improve elements and forms in Theme Anthem

### DIFF
--- a/lib/MBMigration/Builder/Layout/Theme/Anthem/Elements/DynamicElements/Forms/Form.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Anthem/Elements/DynamicElements/Forms/Form.php
@@ -50,6 +50,7 @@ class Form extends DynamicElement
 
         $this->setOptionsForTextColor($sectionData, $options);
 
+
         foreach ($sectionData['items'] as $item) {
             if ($item['category'] == 'text') {
                 if ($item['item_type'] === 'title' && $this->showHeader($sectionData)) {
@@ -78,7 +79,7 @@ class Form extends DynamicElement
             $objBlock->item(0)->addItem($this->button($buttonOptions, $position));
         }
 
-        $objBlock->item(0)->addItem($this->wrapperForm([], 'wrapper'));
+        $objBlock->item(0)->addItem($this->wrapperForm([], $sectionData['settings']['sections']['form']['form_id'] ?? '', 'wrapper'));
 
         $block = $this->replaceIdWithRandom($objBlock->get());
 

--- a/lib/MBMigration/Builder/Layout/Theme/Anthem/Elements/Element.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Anthem/Elements/Element.php
@@ -78,8 +78,11 @@ abstract class Element extends LayoutUtils
             $objBlock->item()->setting('bgColorHex', $sectionData['style']['background-color']);
             $objBlock->item()->setting('mobileBgColorHex', $sectionData['style']['background-color']);
         }
-        if(isset($sectionData['settings']['sections']['background']['filename'])){
-            $objBlock->item()->setting('bgColorOpacity', $this->convertToNumeric($sectionData['style']['opacity_div']['opacity']));
+        if (isset($sectionData['settings']['sections']['background']['filename'])) {
+            $objBlock->item()->setting(
+                'bgColorOpacity',
+                $this->convertToNumeric($sectionData['style']['opacity_div']['opacity'])
+            );
             $objBlock->item()->setting(
                 'mobileBgColorOpacity',
                 $this->convertToNumeric($sectionData['style']['opacity_div']['opacity'])
@@ -450,11 +453,14 @@ abstract class Element extends LayoutUtils
     /**
      * @throws Exception
      */
-    protected function wrapperForm(array $options = [], $type = 'main')
+    protected function wrapperForm(array $options = [], $formId = '', $type = 'main')
     {
         $jsonDecode = $this->initData();
         $decoded = $jsonDecode['global'];
         $objForm = new ItemBuilder($decoded['wrapper--form'][$type]);
+        if (!empty($formId)) {
+            $objForm->item()->setting('form', $formId);
+        }
         if (!empty($options)) {
             foreach ($options as $key => $value) {
                 $objForm->item()->setting($key, $value);
@@ -608,7 +614,10 @@ abstract class Element extends LayoutUtils
             if ($pTag->hasChildNodes()) {
                 foreach ($pTag->childNodes as $childNode) {
 
-                    if ($childNode->nodeType === XML_ELEMENT_NODE && !in_array(strtolower($childNode->nodeName), $ignoreTags)) {
+                    if ($childNode->nodeType === XML_ELEMENT_NODE && !in_array(
+                            strtolower($childNode->nodeName),
+                            $ignoreTags
+                        )) {
                         return true;
                     }
 


### PR DESCRIPTION
The `Element.php` and `Forms/Form.php` classes under `Theme Anthem` in the MBMigration library have been refactored for better code readability. Changes also include the addition of formId to the `wrapperForm` method and the adjustment in the conditions for checking background filename and child node's types. The form referenced when building the wrapper form is now more flexible.