### PR TITLE
Refactor font handling across multiple themes

### DIFF
--- a/lib/MBMigration/Builder/Fonts/FontsController.php
+++ b/lib/MBMigration/Builder/Fonts/FontsController.php
@@ -159,6 +159,22 @@ class FontsController extends builderUtils
         return false;
     }
 
+    static public function getFontsFamily(): array
+    {
+        $fontFamily = [];
+        $cache = VariableCache::getInstance();
+        $fonts = $cache->get('fonts', 'settings');
+        foreach ($fonts as $font) {
+            if (isset($font['name']) && $font['name'] === 'primary') {
+                $fontFamily['Default'] = $font['uuid'];
+            } else {
+                $fontFamily['kit'][$font['fontFamily']] = $font['uuid'];
+            }
+        }
+
+        return $fontFamily;
+    }
+
     protected function checkArrayPath($array, $path, $check = ''): bool
     {
         $keys = explode('/', $path);

--- a/lib/MBMigration/Builder/Layout/Theme/Anthem/Anthem.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Anthem/Anthem.php
@@ -5,6 +5,7 @@ namespace MBMigration\Builder\Layout\Theme\Anthem;
 use Exception;
 use MBMigration\Browser\Browser;
 use MBMigration\Browser\BrowserPage;
+use MBMigration\Builder\Fonts\FontsController;
 use MBMigration\Builder\Layout\LayoutUtils;
 use MBMigration\Builder\Layout\Theme\Anthem\Elements\Items\SubMenu;
 use MBMigration\Builder\Utils\FamilyTreeMenu;
@@ -53,7 +54,7 @@ class Anthem extends LayoutUtils
         $this->browserPage = $browserPage;
         $this->browser = $browser;
 
-        $this->fontFamily = $this->getFontsFamily();
+        $this->fontFamily = FontsController::getFontsFamily();
 
 //        ThemePreProcess::treeMenu();
 
@@ -207,7 +208,7 @@ class Anthem extends LayoutUtils
      * @param string $nameSectionId The name of the section ID parameter. Default is 'id'.
      * @throws Exception If failed to extract data.
      */
-    private function ExtractDataFromPage(&$SectionPage, BrowserPage $browserPage, $nameSectionId = 'id')
+    private function ExtractDataFromPage(array &$SectionPage, BrowserPage $browserPage, string $nameSectionId = 'id')
     {
         $selectorIcon = "[data-socialicon],[style*=\"font-family: 'Mono Social Icons Font'\"],[data-icon]";
         $browserPage->ExtractHover($selectorIcon);
@@ -280,22 +281,6 @@ class Anthem extends LayoutUtils
                 }
             }
         }
-    }
-
-    protected function getFontsFamily(): array
-    {
-        $fontFamily = [];
-        $cache = VariableCache::getInstance();
-        $fonts = $cache->get('fonts', 'settings');
-        foreach ($fonts as $font) {
-            if (isset($font['name']) && $font['name'] === 'primary') {
-                $fontFamily['Default'] = $font['uuid'];
-            } else {
-                $fontFamily['kit'][$font['fontFamily']] = $font['uuid'];
-            }
-        }
-
-        return $fontFamily;
     }
 
     private function ExtractStyleSection($browserPage, int $sectionId): array

--- a/lib/MBMigration/Builder/Layout/Theme/Anthem/Elements/Element.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Anthem/Elements/Element.php
@@ -5,6 +5,7 @@ namespace MBMigration\Builder\Layout\Theme\Anthem\Elements;
 use DOMDocument;
 use Exception;
 use MBMigration\Builder\Checking;
+use MBMigration\Builder\Fonts\FontsController;
 use MBMigration\Builder\ItemBuilder;
 use MBMigration\Builder\Layout\LayoutUtils;
 use MBMigration\Builder\VariableCache;
@@ -152,25 +153,6 @@ abstract class Element extends LayoutUtils
     /**
      *
      */
-    protected function getFontsFamily(): array
-    {
-        $fontFamily = [];
-        $cache = VariableCache::getInstance();
-        $fonts = $cache->get('fonts', 'settings');
-        foreach ($fonts as $font) {
-            if (isset($font['name']) && $font['name'] === 'primary') {
-                $fontFamily['Default'] = $font['uuid'];
-            } else {
-                $fontFamily[$font['fontFamily']] = $font['uuid'];
-            }
-        }
-
-        return $fontFamily;
-    }
-
-    /**
-     *
-     */
     protected function defaultOptionsForElement($element, &$options): void
     {
         $loadOptions = json_decode($element['options'], true);
@@ -306,7 +288,7 @@ abstract class Element extends LayoutUtils
             'position' => $sectionData['settings']['pagePosition'] ?? '',
             'currentPageURL' => $this->cache->get('CurrentPageURL'),
             'sectionID' => $sectionData['sectionId'],
-            'fontsFamily' => $this->getFontsFamily(),
+            'fontsFamily' => FontsController::getFontsFamily(),
         ];
 
         foreach ($primary as $key => $value) {

--- a/lib/MBMigration/Builder/Layout/Theme/Anthem/Elements/Head.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Anthem/Elements/Head.php
@@ -3,6 +3,7 @@
 namespace MBMigration\Builder\Layout\Theme\Anthem\Elements;
 
 use MBMigration\Browser\BrowserPage;
+use MBMigration\Builder\Fonts\FontsController;
 use MBMigration\Builder\ItemBuilder;
 use MBMigration\Builder\Menu\MenuHandler;
 use MBMigration\Builder\Utils\PathSlugExtractor;
@@ -48,7 +49,7 @@ class Head extends Element
         $this->browser = $browser;
         $this->cache = VariableCache::getInstance();
         $this->jsonDecode = $jsonKitElements;
-        $this->fontFamily = $this->getFontsFamily();
+        $this->fontFamily = FontsController::getFontsFamily();
         $this->brizyAPI = $brizyAPI;
     }
 
@@ -296,22 +297,6 @@ class Head extends Element
                 'DEFAULT_FAMILY' => $this->fontFamily['Default'],
             ]
         );
-    }
-
-    protected function getFontsFamily(): array
-    {
-        $fontFamily = [];
-        $cache = VariableCache::getInstance();
-        $fonts = $cache->get('fonts', 'settings');
-        foreach ($fonts as $font) {
-            if (isset($font['name']) && $font['name'] === 'primary') {
-                $fontFamily['Default'] = $font['uuid'];
-            } else {
-                $fontFamily['kit'][$font['fontFamily']] = $font['uuid'];
-            }
-        }
-
-        return $fontFamily;
     }
 
     private function convertColor($color): string

--- a/lib/MBMigration/Builder/Layout/Theme/Anthem/Elements/Items/SubMenu.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Anthem/Elements/Items/SubMenu.php
@@ -2,6 +2,7 @@
 
 namespace MBMigration\Builder\Layout\Theme\Anthem\Elements\Items;
 
+use MBMigration\Builder\Fonts\FontsController;
 use MBMigration\Builder\ItemBuilder;
 use MBMigration\Builder\Layout\Theme\Anthem\Elements\Element;
 use MBMigration\Builder\Utils\TextTools;
@@ -109,7 +110,7 @@ class SubMenu extends Element
         $SubMenuGeneralParameters = [
             'position'       => $sectionData['settings']['pagePosition'],
             'sectionID'      => $sectionData['sectionId'],
-            'fontsFamily'    => $this->getFontsFamily(),
+            'fontsFamily'    => FontsController::getFontsFamily(),
             'currentPageURL' => $this->cache->get('CurrentPageURL')
         ];
 

--- a/lib/MBMigration/Builder/Layout/Theme/Aurora/Elements/Element.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Aurora/Elements/Element.php
@@ -4,6 +4,7 @@ namespace MBMigration\Builder\Layout\Theme\Aurora\Elements;
 
 use Exception;
 use MBMigration\Builder\Checking;
+use MBMigration\Builder\Fonts\FontsController;
 use MBMigration\Builder\ItemBuilder;
 use MBMigration\Builder\Layout\LayoutUtils;
 use MBMigration\Builder\VariableCache;
@@ -114,20 +115,6 @@ abstract class Element extends LayoutUtils
             $options = array_merge($options, ['fontFamily' => $item['settings']['used_fonts']['uuid']]);
         }
         $options = array_merge($options, ['fontType' => $item['item_type']]);
-    }
-
-    /**
-     *
-     */
-    protected function getFontsFamily(): array
-    {
-        $fontFamily = [];
-        $cache = VariableCache::getInstance();
-        $fonts = $cache->get('fonts', 'settings');
-        foreach ($fonts as $font) {
-            $fontFamily[$font['fontFamily']] = $font['uuid'];
-        }
-        return $fontFamily;
     }
 
     /**
@@ -259,7 +246,7 @@ abstract class Element extends LayoutUtils
             'position' => $sectionData['settings']['pagePosition'],
             'currentPageURL' => $this->cache->get('CurrentPageURL'),
             'sectionID' => $sectionData['sectionId'],
-            'fontsFamily' => $this->getFontsFamily()
+            'fontsFamily' => FontsController::getFontsFamily()
         ];
 
         $padding = JS::StylesPaddingExtractor($options['sectionID'], $options['currentPageURL']);

--- a/lib/MBMigration/Builder/Layout/Theme/Solstice/Elements/Element.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Solstice/Elements/Element.php
@@ -4,6 +4,7 @@ namespace MBMigration\Builder\Layout\Theme\Solstice\Elements;
 
 use Exception;
 use MBMigration\Builder\Checking;
+use MBMigration\Builder\Fonts\FontsController;
 use MBMigration\Builder\ItemBuilder;
 use MBMigration\Builder\Layout\LayoutUtils;
 use MBMigration\Builder\VariableCache;
@@ -101,24 +102,6 @@ abstract class Element extends LayoutUtils
         if (isset($item['item_type'])){
             $options = array_merge($options, ['fontType' => $item['item_type']]);
         }
-    }
-
-    /**
-     *
-     */
-    protected function getFontsFamily(): array
-    {
-        $fontFamily = [];
-        $cache = VariableCache::getInstance();
-        $fonts = $cache->get('fonts', 'settings');
-        foreach ($fonts as $font) {
-            if(isset($font['name']) && $font['name'] === 'primary'){
-                $fontFamily['Default'] = $font['uuid'];
-            } else {
-                $fontFamily[$font['fontFamily']] = $font['uuid'];
-            }
-        }
-        return $fontFamily;
     }
 
     /**
@@ -253,7 +236,7 @@ abstract class Element extends LayoutUtils
             'position' => $sectionData['settings']['pagePosition'] ?? '',
             'currentPageURL' => $this->cache->get('CurrentPageURL'),
             'sectionID' => $sectionData['sectionId'],
-            'fontsFamily' => $this->getFontsFamily()
+            'fontsFamily' => FontsController::getFontsFamily(),
         ];
 
         foreach ($primary as $key => $value) {

--- a/lib/MBMigration/Builder/Layout/Theme/Solstice/Elements/Head.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Solstice/Elements/Head.php
@@ -3,6 +3,7 @@
 namespace MBMigration\Builder\Layout\Theme\Solstice\Elements;
 
 use MBMigration\Browser\BrowserPage;
+use MBMigration\Builder\Fonts\FontsController;
 use MBMigration\Builder\ItemBuilder;
 use MBMigration\Builder\Layout\Theme\Anthem\Elements\Element;
 use MBMigration\Builder\Utils\PathSlugExtractor;
@@ -45,7 +46,7 @@ class Head extends Element
         $this->browser = $browser;
         $this->cache = VariableCache::getInstance();
         $this->jsonDecode = $jsonKitElements;
-        $this->fontFamily = $this->getFontsFamily();
+        $this->fontFamily = FontsController::getFontsFamily();
     }
 
     public function getElement(array $elementData = [])
@@ -290,19 +291,4 @@ class Head extends Element
         );
     }
 
-    protected function getFontsFamily(): array
-    {
-        $fontFamily = [];
-        $cache = VariableCache::getInstance();
-        $fonts = $cache->get('fonts', 'settings');
-        foreach ($fonts as $font) {
-            if (isset($font['name']) && $font['name'] === 'primary') {
-                $fontFamily['Default'] = $font['uuid'];
-            } else {
-                $fontFamily['kit'][$font['fontFamily']] = $font['uuid'];
-            }
-        }
-
-        return $fontFamily;
-    }
 }

--- a/lib/MBMigration/Builder/Layout/Theme/Solstice/Solstice.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Solstice/Solstice.php
@@ -5,6 +5,7 @@ namespace MBMigration\Builder\Layout\Theme\Solstice;
 use Exception;
 use MBMigration\Browser\Browser;
 use MBMigration\Browser\BrowserPage;
+use MBMigration\Builder\Fonts\FontsController;
 use MBMigration\Builder\Layout\LayoutUtils;
 use MBMigration\Builder\Utils\FamilyTreeMenu;
 use MBMigration\Builder\Utils\PathSlugExtractor;
@@ -51,7 +52,7 @@ class Solstice extends LayoutUtils
         $this->browserPage = $browserPage;
         $this->browser = $browser;
 
-        $this->fontFamily = $this->getFontsFamily();
+        $this->fontFamily = FontsController::getFontsFamily();
 
 //        ThemePreProcess::treeMenu();
 
@@ -272,22 +273,6 @@ class Solstice extends LayoutUtils
                 }
             }
         }
-    }
-
-    protected function getFontsFamily(): array
-    {
-        $fontFamily = [];
-        $cache = VariableCache::getInstance();
-        $fonts = $cache->get('fonts', 'settings');
-        foreach ($fonts as $font) {
-            if (isset($font['name']) && $font['name'] === 'primary') {
-                $fontFamily['Default'] = $font['uuid'];
-            } else {
-                $fontFamily['kit'][$font['fontFamily']] = $font['uuid'];
-            }
-        }
-
-        return $fontFamily;
     }
 
     private function ExtractStyleSection($browserPage, int $sectionId): array

--- a/lib/MBMigration/Builder/PageBuilder.php
+++ b/lib/MBMigration/Builder/PageBuilder.php
@@ -3,6 +3,7 @@
 namespace MBMigration\Builder;
 
 use MBMigration\Browser\Browser;
+use MBMigration\Builder\Fonts\FontsController;
 use MBMigration\Builder\Layout\Common\Exception\ElementNotFound;
 use MBMigration\Builder\Layout\Common\LayoutElementFactory;
 use MBMigration\Builder\Layout\Common\ThemeContext;
@@ -41,7 +42,7 @@ class PageBuilder
         $design = $this->cache->get('settings')['design'];
         $slug = $this->cache->get('tookPage')['slug'];
 
-        $fontFamily = $this->getFontsFamily();
+        $fontFamily = FontsController::getFontsFamily();
 
         $url = PathSlugExtractor::getFullUrl($slug);
 
@@ -118,22 +119,6 @@ class PageBuilder
         echo " => Current Page: {$pageName} | Status: ".json_encode(
                 $this->cache->get('Status')
             )."| Time: $executeTime \n";
-    }
-
-    private function getFontsFamily(): array
-    {
-        $fontFamily = [];
-        $cache = VariableCache::getInstance();
-        $fonts = $cache->get('fonts', 'settings');
-        foreach ($fonts as $font) {
-            if (isset($font['name']) && $font['name'] === 'primary') {
-                $fontFamily['Default'] = $font['uuid'];
-            } else {
-                $fontFamily['kit'][$font['fontFamily']] = $font['uuid'];
-            }
-        }
-
-        return $fontFamily;
     }
 
     public function closeBrowser()


### PR DESCRIPTION
Transferred the responsibility of retrieving font families from multiple theme and layout files into the FontsController. This eliminates code duplication and centralizes the responsibility of font handling to one class. The changes improve code readability and maintainability.