### PR TITLE
Remove color palette related functions

### DIFF
--- a/lib/MBMigration/Layer/MB/MBProjectDataCollector.php
+++ b/lib/MBMigration/Layer/MB/MBProjectDataCollector.php
@@ -154,9 +154,6 @@ class MBProjectDataCollector
         }
 
         $parameter = json_decode($siteData['parameter'], true);
-        if (!array_key_exists('palette', $parameter)) {
-            $parameter['palette'] = $this->getPalettes($siteData['palette_uuid']);
-        }
 
         $siteData['parameter'] = $parameter;
         $siteData['fonts'] = $this->getFonts($parameter, $siteData['font_theme_uuid']);
@@ -371,31 +368,6 @@ class MBProjectDataCollector
         return $result;
     }
 
-    /**
-     * @throws Exception
-     */
-    private function getPalettes($paletteUUID): ?array
-    {
-        $palette = null;
-
-        if ($paletteUUID === null) {
-            return $palette;
-        }
-
-        $palettes = $this->db->requestArray("SELECT id from palettes WHERE uuid = '$paletteUUID'");
-        $colorsKit = $this->db->requestArray(
-            "SELECT * from colors WHERE palette_id = '".$palettes[0]['id']."' ORDER BY position"
-        );
-        foreach ($colorsKit as $color) {
-            $palette[] = [
-                'tag' => $color['tag'],
-                'color' => $color['color'],
-            ];
-        }
-
-        return $palette;
-    }
-
     public function getPages(): array
     {
         Logger::instance()->info('Get parent pages');
@@ -580,10 +552,6 @@ class MBProjectDataCollector
 //                "SELECT name, category, settings FROM section_layouts WHERE uuid  = '".$pageSections['section_layout_uuid']."'"
 //            );
             $settings = json_decode($pageSections['settings'], true);
-
-            if (!array_key_exists('color', $settings)) {
-                $settings['color'] = $this->cache->get('subpalette', 'parameter')['subpalette1'];
-            }
 
             $result[] = [
                 'id' => $pageSections['id'],

--- a/lib/MBMigration/MigrationPlatform.php
+++ b/lib/MBMigration/MigrationPlatform.php
@@ -459,18 +459,6 @@ class MigrationPlatform
         }
     }
 
-    private function getColorFromPalette(string $color)
-    {
-        $subPalette = $this->cache->get('subpalette', 'parameter');
-        foreach ($subPalette as $key => $palette) {
-            if ($key === $color) {
-                return $palette;
-            }
-        }
-
-        return false;
-    }
-
     private function getCollectionItem($slug)
     {
         $ListPages = $this->cache->get('ListPages');
@@ -849,28 +837,6 @@ class MigrationPlatform
 
         return sprintf('%02d:%02d:%02d', $hours, $minutes, $seconds);
     }
-
-//    private function updateColorSection(array &$mainSection): void
-//    {
-//        foreach ($mainSection as $item => &$value) {
-//            if (is_array($value)) {
-//                $this->updateColorSection($value);
-//            }
-//            if ($item === 'subpalette') {
-//                $value = $this->getColorFromPalette($value);
-//            }
-//        }
-//    }
-
-//    private function createPalette(): void
-//    {
-//        $colorMapper = new ColorMapper();
-//        $colorKit = $this->colorPalette();
-//        $design = $this->cache->get('design', 'settings');
-//        $this->cache->set('subpalette', [], 'parameter');
-//        $subPalette = $colorMapper->getPalette('Anthem', $colorKit);
-//        $this->cache->update('subpalette', $subPalette, 'parameter');
-//    }
 
     /**
      * @throws Exception


### PR DESCRIPTION
Removed several methods in MigrationPlatform.php and MBProjectDataCollector.php which were used to manage color palettes. These methods were deleted because they are not used anywhere in the current code, making the code cleaner and leaner. Code blocks that were commented out were also removed to enhance clarity.