### PR TITLE
Add submenu styling options to layout builder

### DIFF
--- a/lib/MBMigration/Builder/Layout/Theme/Anthem/Elements/Head.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Anthem/Elements/Head.php
@@ -250,6 +250,9 @@ class Head extends Element
 
         $defOptions = [
             'activeSubMenuColorHex' => $result['data']['hoverColorHex'] ?? '#827777',
+            'hoverSubMenuBgColorHex' => $result['data']['subMenuBgColorHex'] ?? '#827777',
+            'hoverSubMenuColorHex' => $result['data']['subMenuColorHex'] ?? '#827777',
+            'subMenuColorOpacity' => 0.75,
             'menuPadding' => 5,
             'menuPaddingBottom' => 5,
             "borderRadiusType"=> "grouped",


### PR DESCRIPTION
Extended the layout builder functionality in the 'Anthem' theme by providing new submenu styling options. Three new definitions for submenu hover background color, submenu color, and submenu color opacity have been added to the default options array.