### PR TITLE
Adjust active and sub menu opacity in theme layout

### DIFF
--- a/lib/MBMigration/Builder/Layout/Theme/Anthem/Elements/Head.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Anthem/Elements/Head.php
@@ -255,9 +255,10 @@ class Head extends Element
 
         $defOptions = [
             'activeSubMenuColorHex' => $result['data']['subMenuColorHex'] ?? '#827777',
+            'activeSubMenuColorOpacity' => 1,
             'hoverSubMenuBgColorHex' => $result['data']['subMenuBgColorHex'] ?? '#827777',
             'hoverSubMenuColorHex' => $result['data']['subMenuColorHex'] ?? '#827777',
-            'subMenuColorOpacity' => 0.75,
+            'subMenuColorOpacity' => 0.70,
             'menuPadding' => 5,
             'menuPaddingBottom' => 5,
             "borderRadiusType"=> "grouped",


### PR DESCRIPTION
The default layout theme options have been tweaked for better design consistency. Specifically, the active submenu color opacity was set to full, and the submenu color opacity was slightly reduced. These changes aim to improve visual appeal and enhance display on various devices.