### PR TITLE
Implement donation button style extraction in theme builder

### DIFF
--- a/lib/MBMigration/Builder/Layout/Theme/Anthem/Anthem.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Anthem/Anthem.php
@@ -256,6 +256,23 @@ class Anthem extends LayoutUtils
                 ) ?? [];
             }
 
+            if ($section['category'] === 'donation') {
+
+                $style = [];
+                $buttonStyle = $this->ExtractStyleDonateButton(
+                    $browserPage,
+                    $section['sectionId']
+                ) ?? [];
+                $style = array_merge($style, $buttonStyle);
+
+                $buttonStyle  = $this->ExtractStyleDonateButtonStyle(
+                    $browserPage,
+                    $section['sectionId']
+                ) ?? [];
+                $style = array_merge($style, $buttonStyle);
+                $section['style']['donation']['button'] = $style;
+            }
+
             if (!empty($section['items'])) {
                 foreach ($section['items'] as &$item) {
                     if ($item['category'] === 'text') {
@@ -473,6 +490,90 @@ class Anthem extends LayoutUtils
         }
 
         return $sectionStyles['data'] ?? [];
+    }
+    private function ExtractStyleDonateButton($browserPage, int $sectionId): array
+    {
+        $sectionStyles = $browserPage->evaluateScript(
+            'brizy.getStyles',
+            [
+                'selector' => '[data-id="'.$sectionId.'"] .sites-button-text',
+                'styleProperties' => [
+                    'color',
+                    'text-transform',
+                ],
+                'families' => $this->fontFamily['kit'],
+                'defaultFamily' => $this->fontFamily['Default'],
+                'urlMap' => $this->pageMapping,
+            ]
+        );
+
+        if (array_key_exists('error', $sectionStyles)) {
+            return [];
+        }
+
+        if (isset($sectionStyles['data'])) {
+            $opacityIsSet = false;
+            foreach ($sectionStyles['data'] as $key => $value) {
+                $convertedData = ColorConverter::convertColor(str_replace("px", "", $value));
+                if (is_array($convertedData)) {
+                    $style[$key] = $convertedData['color'];
+                    $style['opacity'] = $convertedData['opacity'];
+                    $opacityIsSet = true;
+                } else {
+                    if ($opacityIsSet && $key == 'opacity') {
+                        continue;
+                    } else {
+                        $style[$key] = $convertedData;
+                    }
+                }
+            }
+        } else {
+            return [];
+        }
+
+        return $style;
+    }
+
+    private function ExtractStyleDonateButtonStyle($browserPage, int $sectionId): array
+    {
+        $sectionStyles = $browserPage->evaluateScript(
+            'brizy.getStyles',
+            [
+                'selector' => '[data-id="'.$sectionId.'"] .sites-button',
+                'styleProperties' => [
+                    'background-color',
+                ],
+                'families' => $this->fontFamily['kit'],
+                'defaultFamily' => $this->fontFamily['Default'],
+                'urlMap' => $this->pageMapping,
+            ]
+        );
+
+        if (array_key_exists('error', $sectionStyles)) {
+            return [];
+        }
+
+        if (isset($sectionStyles['data'])) {
+            $opacityIsSet = false;
+            foreach ($sectionStyles['data'] as $key => $value) {
+                $convertedData = ColorConverter::convertColor(str_replace("px", "", $value));
+                if (is_array($convertedData)) {
+                    $style[$key] = $convertedData['color'];
+                    $style['opacity'] = $convertedData['opacity'];
+                    $opacityIsSet = true;
+                } else {
+                    if ($opacityIsSet && $key == 'opacity') {
+                        continue;
+                    } else {
+                        $style[$key] = $convertedData;
+                    }
+                }
+            }
+        } else {
+            return [];
+        }
+
+        return $style;
     }
 
     private function ExtractStylePage($browserPage): array

--- a/lib/MBMigration/Builder/Layout/Theme/Anthem/Elements/FullText.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Anthem/Elements/FullText.php
@@ -4,6 +4,7 @@ namespace MBMigration\Builder\Layout\Theme\Anthem\Elements;
 
 use DOMException;
 use Exception;
+use MBMigration\Builder\Utils\TextTools;
 use MBMigration\Core\Logger;
 use MBMigration\Builder\ItemBuilder;
 use MBMigration\Builder\VariableCache;
@@ -98,8 +99,16 @@ class FullText extends Element
             if (isset($sectionData['settings']['sections']['donations']['url'])) {
                 $buttonOptions = [
                     'linkExternal' => $sectionData['settings']['sections']['donations']['url'],
-                    'text' => $sectionData['settings']['sections']['donations']['text'] ?? $sectionData['settings']['layout']['donations']['text'],
-                    'linkExternalBlank' => $sectionItem['new_window']
+                    'text' => TextTools::transformText(
+                        $sectionData['settings']['sections']['donations']['text'] ?? $sectionData['settings']['layout']['donations']['text'],
+                        $sectionData['style']['donation']['button']['text-transform'] ?? 'normal'),
+                    'linkExternalBlank' => $sectionItem['new_window'],
+
+                    'bgColorHex' => $sectionData['style']['donation']['button']['background-color'] ?? '#024E69',
+                    'hoverBgColorHex' => $sectionData['style']['donation']['button']['background-color'] ?? '#024E69',
+
+                    'borderStyle' => 'none',
+                    'hoverBorderStyle' => 'none',
                 ];
                 $position = $sectionData['settings']['sections']['donations']['alignment'] ?? 'left';
 


### PR DESCRIPTION
This commit introduces the functionality to extract and apply styles to the donation button in the theme builder. Two new methods, `ExtractStyleDonateButton` and `ExtractStyleDonateButtonStyle`, have been created to handle the extraction process while a transformation method in the `FullText.php` file has been updated to apply the extracted styles. This will ensure the donation button maintains consistent styles and aesthetics across different pages of the website.