### PR TITLE
Add feature to set view order in EventCalendarLayout

### DIFF
--- a/lib/MBMigration/Builder/Layout/Theme/Anthem/Elements/DynamicElements/Events/EventCalendarLayout.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Anthem/Elements/DynamicElements/Events/EventCalendarLayout.php
@@ -122,6 +122,8 @@ class EventCalendarLayout extends DynamicElement
 
         $placeholder = base64_encode('{{ brizy_dc_url_post entityId="' . $collectionItemsForDetailPage . '" }}"');
         $objBlock->item()->item(1)->item()->setting('detailPage', "{{placeholder content='$placeholder'}}");
+        $objBlock->item()->item(1)->item()->setting('featuredViewOrder', 3);
+        $objBlock->item()->item(1)->item()->setting('calendarViewOrder', 1);
 
         $block = $this->replaceIdWithRandom($objBlock->get());
 


### PR DESCRIPTION
This commit introduces settings to specify the "featuredViewOrder" and "calendarViewOrder" in the EventCalendarLayout class. These settings will allow the adjustment of the order in which featured and calendar views appear in the MBMigration theme builder, thereby providing more flexibility in the layout design.