### PR TITLE
Add mobile background color settings in EventCalendarLayout

### DIFF
--- a/lib/MBMigration/Builder/Layout/Theme/Anthem/Elements/DynamicElements/Events/EventCalendarLayout.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Anthem/Elements/DynamicElements/Events/EventCalendarLayout.php
@@ -38,7 +38,9 @@ class EventCalendarLayout extends DynamicElement
         if($this->checkArrayPath($sectionData, 'settings/sections/color/bg')) {
             $blockBg = $sectionData['style']['background-color'];
             $objBlock->item(0)->setting('bgColorPalette','');
+            $objBlock->item(0)->setting('mobileBgColorPalette', '');
             $objBlock->item(0)->setting('bgColorHex', $blockBg);
+            $objBlock->item(0)->setting('mobileBgColorHex', $blockBg);
         }
 
         $blockHead = false;


### PR DESCRIPTION
This commit adds additional background color settings for mobile view in the EventCalendarLayout. The newly introduced settings allow to set the background color hex code specifically for mobile devices, providing a better visual experience for mobile users. The settings options are 'mobileBgColorPalette' and 'mobileBgColorHex'.