### PR TITLE
Add mobile background color settings in layout themes.

### DIFF
--- a/lib/MBMigration/Builder/Layout/Theme/Anthem/Elements/DynamicElements/Events/EventGalleryLayout.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Anthem/Elements/DynamicElements/Events/EventGalleryLayout.php
@@ -41,7 +41,9 @@ class EventGalleryLayout extends DynamicElement
         if($this->checkArrayPath($sectionData, 'settings/sections/color/bg')) {
             $blockBg = $sectionData['settings']['sections']['color']['bg'];
             $objBlock->item(0)->setting('bgColorPalette','');
+            $objBlock->item(0)->setting('mobileBgColorPalette', '');
             $objBlock->item(0)->setting('bgColorHex', $blockBg);
+            $objBlock->item(0)->setting('mobileBgColorHex', $blockBg);
         }
 
         $blockHead = false;

--- a/lib/MBMigration/Builder/Layout/Theme/Anthem/Elements/DynamicElements/Events/EventGridLayout.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Anthem/Elements/DynamicElements/Events/EventGridLayout.php
@@ -33,7 +33,9 @@ class EventGridLayout extends DynamicElement
         if($this->checkArrayPath($sectionData, 'settings/sections/color/bg')) {
             $blockBg = $sectionData['settings']['sections']['color']['bg'];
             $objBlock->item(0)->setting('bgColorPalette','');
+            $objBlock->item(0)->setting('mobileBgColorPalette', '');
             $objBlock->item(0)->setting('bgColorHex', $blockBg);
+            $objBlock->item(0)->setting('mobileBgColorHex', $blockBg);
         }
 
         $blockHead = false;

--- a/lib/MBMigration/Builder/Layout/Theme/Anthem/Elements/DynamicElements/Events/EventListLayout.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Anthem/Elements/DynamicElements/Events/EventListLayout.php
@@ -35,7 +35,9 @@ class EventListLayout extends DynamicElement
         if($this->checkArrayPath($sectionData, 'settings/sections/color/bg')) {
             $blockBg = $sectionData['settings']['sections']['color']['bg'];
             $objBlock->item(0)->setting('bgColorPalette','');
+            $objBlock->item(0)->setting('mobileBgColorPalette', '');
             $objBlock->item(0)->setting('bgColorHex', $blockBg);
+            $objBlock->item(0)->setting('mobileBgColorHex', $blockBg);
         }
 
         $blockHead = false;


### PR DESCRIPTION
Updated the EventGridLayout, EventGalleryLayout, and EventListLayout files in the Anthem theme to include settings for mobile background color palette and hex. This enhancement ensures consistency and flexibility in color settings across devices.