### PR TITLE
Refactor new_window condition check in Element.php

### DIFF
--- a/lib/MBMigration/Builder/Layout/Theme/Anthem/Elements/Element.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Anthem/Elements/Element.php
@@ -630,7 +630,7 @@ abstract class Element extends LayoutUtils
     {
         $sectionItem = [];
         $slash = '';
-        if (!$item['new_window']) {
+        if ($item['new_window'] === true) {
             $sectionItem['new_window'] = 'on';
         } else {
             $sectionItem['new_window'] = 'off';


### PR DESCRIPTION
The if condition for 'new_window' has been updated in the Element.php file. Previously, the condition was checking for not 'new_window'. Now it explicitly checks if 'new_window' is set to true, improving readability and precision.