### PR TITLE
Update opacity key name in Element.php

### DIFF
--- a/lib/MBMigration/Builder/Layout/Theme/Anthem/Elements/Element.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Anthem/Elements/Element.php
@@ -130,9 +130,8 @@ abstract class Element extends LayoutUtils
                 $objBlock->item()->setting('bgImageSrc', $sectionData['settings']['sections']['background']['photo']);
                 $objBlock->item()->setting(
                     'bgColorOpacity',
-                    $this->convertToNumeric($sectionData['style']['opacity_div']['opacity'] ?? 1)
+                    $this->convertToNumeric($sectionData['style']['opacity'] ?? 1)
                 );
-
             }
         }
     }


### PR DESCRIPTION
The opacity key name under style was changed from 'opacity_div' to 'opacity'. The change reflects the updated structure of the data passed to the 'Element' class. This ensures that the opacity value is correctly extracted and processed.