### PR TITLE
Skip hidden menu items in layout builder

### DIFF
--- a/lib/MBMigration/Builder/Layout/Theme/Anthem/Elements/Head.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Anthem/Elements/Head.php
@@ -126,6 +126,10 @@ class Head extends Element
     {
         $treeMenu = [];
         foreach ($menuList as $item) {
+            if ($item['hidden'] == true) {
+                continue;
+            }
+
             $blockMenu['value']['itemId'] = $item['collection'];
             $blockMenu['value']['title'] = $item['name'];
             if ($item['slug'] == 'home') {
@@ -140,7 +144,14 @@ class Head extends Element
             }
             $blockMenu['value']['items'] = $this->creatingMenuTree($item['child'], $blockMenu);
             if ($item['landing'] == false) {
-                $blockMenu['value']['url'] = $blockMenu['value']['items'][0]['value']['url'];
+                $i = 0;
+                foreach ($item['child'] as $child) {
+                    if ($child['hidden'] == false) {
+                        $blockMenu['value']['url'] = $blockMenu['value']['items'][$i]['value']['url'];
+                        break;
+                    }
+                    $i++;
+                }
             }
 
             $encodeItem = json_encode($blockMenu);


### PR DESCRIPTION
This commit adds functionality to ignore hidden items while building the menu tree in the layout builder. It further modifies the URL assignment process to ensure it only picks up non-hidden items from child list, thus improving responsiveness and correctness of the menu tree.