### PR TITLE
Update path to 'opacity' in Element.php

### DIFF
--- a/lib/MBMigration/Builder/Layout/Theme/Anthem/Elements/Element.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Anthem/Elements/Element.php
@@ -130,7 +130,7 @@ abstract class Element extends LayoutUtils
                 $objBlock->item()->setting('bgImageSrc', $sectionData['settings']['sections']['background']['photo']);
                 $objBlock->item()->setting(
                     'bgColorOpacity',
-                    $this->convertToNumeric($sectionData['style']['opacity'] ?? 1)
+                    $this->convertToNumeric($sectionData['settings']['sections']['background']['opacity'] ?? 1)
                 );
             }
         }


### PR DESCRIPTION
The path to 'opacity' property was incorrect and would have caused errors during theme migration. This commit fixes the path, ensuring that the opacity value of a background element is correctly fetched and processed.