### PR TITLE
Add slider dots color configuration in GalleryLayout

### DIFF
--- a/lib/MBMigration/Builder/Layout/Theme/Anthem/Elements/GalleryLayout.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Anthem/Elements/GalleryLayout.php
@@ -62,6 +62,7 @@ class GalleryLayout extends Element
         }
 
         $colorArrows = $this->getContrastColor($bodyBgColor);
+
         $block['value']['sliderArrowsColorHex'] = $colorArrows;
         $block['value']['sliderArrowsColorOpacity'] = 0.75;
         $block['value']['sliderArrowsColorPalette'] = '';
@@ -69,6 +70,14 @@ class GalleryLayout extends Element
         $block['value']['hoverSliderArrowsColorHex'] = $colorArrows;
         $block['value']['hoverSliderArrowsColorOpacity'] = 1;
         $block['value']['hoverSliderArrowsColorPalette'] = '';
+
+        $block['value']['sliderDotsColorHex'] = $colorArrows;
+        $block['value']['sliderDotsColorOpacity'] = 0.75;
+        $block['value']['sliderDotsColorPalette'] = '';
+
+        $block['value']['hoverSliderDotsColorHex'] = $colorArrows;
+        $block['value']['hoverSliderDotsColorOpacity'] = 1;
+        $block['value']['hoverSliderDotsColorPalette'] = '';
 
         foreach ($sectionData['items'] as $item){
             if(!$item['uploadStatus']) {


### PR DESCRIPTION
Additional color attributes for the slider dots have been added to the GalleryLayout in the Anthem theme. The added configurations allow control over the color, opacity, and color palette of both the slider dots and their hover state.