### PR TITLE
Refactor listItem in foreach loop to reference

### DIFF
--- a/lib/MBMigration/Builder/Layout/Theme/Anthem/Anthem.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Anthem/Anthem.php
@@ -302,7 +302,7 @@ class Anthem extends LayoutUtils
                         case "accordion":
                             $this->ExtractItemContent($item['item'], $browserPage);
 
-                            foreach ($item['item'] as $listItem) {
+                            foreach ($item['item'] as &$listItem) {
                                 if ($listItem['category']=== "photo") {
                                     $target = $this->ExtractTargetLinkFromPhoto(
                                         $browserPage,


### PR DESCRIPTION
In the Anthem Theme, we have changed how we handle the listItem variable within the foreach loop. Now, by referencing the listItem, we are able to directly modify the original array during each iteration.