### PR TITLE
Add hasNode and getNodeText functions to StyleExtractor

### DIFF
--- a/lib/MBMigration/Builder/Layout/Theme/Anthem/Anthem.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Anthem/Anthem.php
@@ -318,9 +318,17 @@ class Anthem extends LayoutUtils
                             }
                             break;
                         case "media":
-                            $result = $browserPage->hasNode('[data-id="'.$item['id'].'"]');
-
-                            $a= 1+3;
+                            $section['style']['mediaGridContainer'] =  $this->hasNode(
+                                $browserPage,
+                                $section['sectionId'] ?? $section['id'],
+                                '.media-grid-container');
+                            if (!$section['style']['mediaGridContainer']) {
+                                $section['style']['containTitle'] = $this->getNodeText(
+                                    $browserPage,
+                                    $section['sectionId'] ?? $section['id'],
+                                    ".media-video-title");
+                            }
+                            break;
                     }
 
                 }
@@ -679,6 +687,42 @@ class Anthem extends LayoutUtils
         }
 
         return $style;
+    }
+
+    private function hasNode($browserPage, int $sectionId, string $selector): bool
+    {
+        $style = [];
+        $sectionStyles = $browserPage->evaluateScript(
+            'brizy.dom.hasNode',
+            [
+                'selector' => '[data-id="'.$sectionId.'"] '.$selector,
+            ]
+        );
+
+        if (array_key_exists('error', $sectionStyles)) {
+            return false;
+        }
+
+        return $sectionStyles['data']['hasNode'] ?? false;
+    }
+
+    private function getNodeText($browserPage, int $sectionId, string $selector)
+    {
+        $style = [];
+
+        $selector = '[data-id="'.$sectionId.'"] '.$selector;
+        $sectionStyles = $browserPage->evaluateScript(
+            'brizy.dom.getNodeText',
+            [
+                'selector' => $selector,
+            ]
+        );
+
+        if (array_key_exists('error', $sectionStyles)) {
+            return false;
+        }
+
+        return $sectionStyles['data']['contain'] ?? false;
     }
 
     private function ExtractTextContent($browserPage, int $mbSectionItemId)

--- a/lib/MBMigration/Builder/Layout/Theme/Anthem/Assets/dist/index.js
+++ b/lib/MBMigration/Builder/Layout/Theme/Anthem/Assets/dist/index.js
@@ -356,6 +356,62 @@
     }
   });
 
+  // ../../../../../../../packages/elements/src/Dom/getNodeText.ts
+  var getNodeText;
+  var init_getNodeText = __esm({
+    "../../../../../../../packages/elements/src/Dom/getNodeText.ts"() {
+      "use strict";
+      init_getData();
+      getNodeText = (entry) => {
+        const { selector } = entry;
+        if (!selector) {
+          return {
+            error: "Selector not found"
+          };
+        }
+        const element = document.querySelector(selector);
+        if (element) {
+          return createData({ data: element.textContent });
+        }
+        return {
+          error: "Selector not found"
+        };
+      };
+    }
+  });
+
+  // ../../../../../../../packages/elements/src/Dom/hasNode.ts
+  var hasNode;
+  var init_hasNode = __esm({
+    "../../../../../../../packages/elements/src/Dom/hasNode.ts"() {
+      "use strict";
+      init_getData();
+      hasNode = (entry) => {
+        const { selector } = entry;
+        if (!selector) {
+          return {
+            error: "Selector not found"
+          };
+        }
+        const data = {
+          hasNode: !!document.querySelector(selector)
+        };
+        return createData({ data });
+      };
+    }
+  });
+
+  // src/Dom/index.ts
+  var dom;
+  var init_Dom = __esm({
+    "src/Dom/index.ts"() {
+      "use strict";
+      init_getNodeText();
+      init_hasNode();
+      dom = { hasNode, getNodeText };
+    }
+  });
+
   // src/GlobalMenu/index.ts
   var run;
   var init_GlobalMenu = __esm({
@@ -4010,6 +4066,7 @@
   var require_src = __commonJS({
     "src/index.ts"() {
       init_Accordion2();
+      init_Dom();
       init_GlobalMenu();
       init_Image2();
       init_Menu();
@@ -4024,7 +4081,8 @@
         getText: getText2,
         getImage,
         getAccordion,
-        getTabs
+        getTabs,
+        dom
       };
     }
   });

--- a/lib/MBMigration/Builder/Layout/Theme/Anthem/Assets/src/Dom/index.ts
+++ b/lib/MBMigration/Builder/Layout/Theme/Anthem/Assets/src/Dom/index.ts
@@ -1,0 +1,4 @@
+import { getNodeText } from "elements/src/Dom/getNodeText";
+import { hasNode } from "elements/src/Dom/hasNode";
+
+export const dom = { hasNode, getNodeText };

--- a/lib/MBMigration/Builder/Layout/Theme/Anthem/Assets/src/StyleExtractor/index.ts
+++ b/lib/MBMigration/Builder/Layout/Theme/Anthem/Assets/src/StyleExtractor/index.ts
@@ -1,4 +1,6 @@
 export {
   styleExtractor as run,
-  attributesExtractor as attributeRun
+  attributesExtractor as attributeRun,
+  getNodeText as getNodeText,
+  hasNode as hasNode,
 } from "elements/src/StyleExtractor";

--- a/lib/MBMigration/Builder/Layout/Theme/Anthem/Assets/src/index.ts
+++ b/lib/MBMigration/Builder/Layout/Theme/Anthem/Assets/src/index.ts
@@ -1,4 +1,5 @@
 import { run as getAccordion } from "./Accordion";
+import { dom } from "./Dom";
 import { run as globalMenuExtractor } from "./GlobalMenu";
 import { run as getImage } from "./Image";
 import { run as getMenu } from "./Menu";
@@ -17,5 +18,6 @@ window.brizy = {
   getText,
   getImage,
   getAccordion,
-  getTabs
+  getTabs,
+  dom
 };

--- a/lib/MBMigration/Builder/Layout/Theme/Bloom/Assets/src/Dom/index.ts
+++ b/lib/MBMigration/Builder/Layout/Theme/Bloom/Assets/src/Dom/index.ts
@@ -1,0 +1,4 @@
+import { getNodeText } from "elements/src/Dom/getNodeText";
+import { hasNode } from "elements/src/Dom/hasNode";
+
+export const dom = { hasNode, getNodeText };

--- a/lib/MBMigration/Builder/Layout/Theme/Bloom/Assets/src/StyleExtractor/index.ts
+++ b/lib/MBMigration/Builder/Layout/Theme/Bloom/Assets/src/StyleExtractor/index.ts
@@ -1,4 +1,6 @@
 export {
   styleExtractor as run,
-  attributesExtractor as attributeRun
+  attributesExtractor as attributeRun,
+  getNodeText as getNodeText,
+  hasNode as hasNode,
 } from "elements/src/StyleExtractor";

--- a/lib/MBMigration/Builder/Layout/Theme/Bloom/Assets/src/index.ts
+++ b/lib/MBMigration/Builder/Layout/Theme/Bloom/Assets/src/index.ts
@@ -1,3 +1,4 @@
+import { dom } from "./Dom";
 import { getMenuItem, getSubMenuItem } from "./Menu";
 import {
   attributeRun as getAttributes,
@@ -10,5 +11,6 @@ window.brizy = {
   getSubMenuItem,
   getAttributes,
   getStyles,
-  getText
+  getText,
+  dom
 };

--- a/lib/MBMigration/Builder/Layout/Theme/Voyage/Assets/src/Dom/index.ts
+++ b/lib/MBMigration/Builder/Layout/Theme/Voyage/Assets/src/Dom/index.ts
@@ -1,0 +1,4 @@
+import { getNodeText } from "elements/src/Dom/getNodeText";
+import { hasNode } from "elements/src/Dom/hasNode";
+
+export const dom = { hasNode, getNodeText };

--- a/lib/MBMigration/Builder/Layout/Theme/Voyage/Assets/src/StyleExtractor/index.ts
+++ b/lib/MBMigration/Builder/Layout/Theme/Voyage/Assets/src/StyleExtractor/index.ts
@@ -1,4 +1,6 @@
 export {
   styleExtractor as run,
-  attributesExtractor as attributeRun
+  attributesExtractor as attributeRun,
+  getNodeText as getNodeText,
+  hasNode as hasNode
 } from "elements/src/StyleExtractor";

--- a/lib/MBMigration/Builder/Layout/Theme/Voyage/Assets/src/index.ts
+++ b/lib/MBMigration/Builder/Layout/Theme/Voyage/Assets/src/index.ts
@@ -1,3 +1,4 @@
+import { dom } from "./Dom";
 import { getMenuItem, getSubMenuItem } from "./Menu";
 import {
   attributeRun as getAttributes,
@@ -10,5 +11,6 @@ window.brizy = {
   getSubMenuItem,
   getAttributes,
   getStyles,
-  getText
+  getText,
+  dom
 };

--- a/packages/elements/src/Dom/getNodeText.ts
+++ b/packages/elements/src/Dom/getNodeText.ts
@@ -1,0 +1,26 @@
+import { Output } from "../types/type";
+import { createData } from "../utils/getData";
+
+interface Data {
+  selector?: string;
+}
+
+export const getNodeText = (entry: Data): Output => {
+  const { selector } = entry;
+
+  if (!selector) {
+    return {
+      error: "Selector not found"
+    };
+  }
+
+  const element = document.querySelector(selector);
+
+  if (element) {
+    return createData({ data: element.textContent });
+  }
+
+  return {
+    error: "Selector not found"
+  };
+};

--- a/packages/elements/src/Dom/getNodeText.ts
+++ b/packages/elements/src/Dom/getNodeText.ts
@@ -17,7 +17,11 @@ export const getNodeText = (entry: Data): Output => {
   const element = document.querySelector(selector);
 
   if (element) {
-    return createData({ data: element.textContent });
+    const data = {
+      contain: element.textContent
+    };
+
+    return createData({ data });
   }
 
   return {

--- a/packages/elements/src/Dom/hasNode.ts
+++ b/packages/elements/src/Dom/hasNode.ts
@@ -1,0 +1,22 @@
+import { Output } from "../types/type";
+import { createData } from "../utils/getData";
+
+interface Data {
+  selector?: string;
+}
+
+export const hasNode = (entry: Data): Output => {
+  const { selector } = entry;
+
+  if (!selector) {
+    return {
+      error: "Selector not found"
+    };
+  }
+
+  const data = {
+    hasNode: !!document.querySelector(selector)
+  };
+
+  return createData({ data });
+};

--- a/packages/elements/src/StyleExtractor/index.ts
+++ b/packages/elements/src/StyleExtractor/index.ts
@@ -1,7 +1,7 @@
-import { Output } from "../types/type";
-import { createData } from "../utils/getData";
-import { getDataByEntry } from "../utils/getDataByEntry";
-import { Literal } from "utils";
+import {Output} from "../types/type";
+import {createData} from "../utils/getData";
+import {getDataByEntry} from "../utils/getDataByEntry";
+import {Literal} from "utils";
 
 export interface Data {
   selector: string;
@@ -54,3 +54,44 @@ export const attributesExtractor = (_entry: Data): Output => {
   });
   return createData({ data });
 };
+
+export const hasNode = (_entry: Data): Output => {
+  const entry = window.isDev ? getDataByEntry(_entry) : _entry;
+
+  const { selector} = entry;
+
+  const data: Record<string, string | null> = {};
+
+  if (!selector) {
+    return {
+      error: `Selector not found`
+    };
+  }
+
+  data['hasNode'] = document.querySelector(selector) ? 'true' : 'false';
+
+  return createData({ data });
+};
+
+export const getNodeText = (_entry: Data): Output => {
+  const entry = window.isDev ? getDataByEntry(_entry) : _entry;
+
+  const { selector} = entry;
+
+  const data: Record<string, string | null> = {};
+
+  if (!selector) {
+    return {
+      error: `Selector not found`
+    };
+  }
+
+  const element = document.querySelector(selector);
+
+  if (element) {
+    data['textNode'] = element.textContent;
+  }
+
+  return createData({ data });
+};
+


### PR DESCRIPTION
The StyleExtractor module has been enhanced by adding two new functions, hasNode and getNodeText. These functions check if an HTML node exists, and if it does, they retrieve its text content. The new functions have also been imported into the various theme asset libraries for further use.