### PR TITLE
Set default values for button colors and pass palette to detail page …

### DIFF
--- a/lib/MBMigration/Builder/Layout/Theme/Anthem/Elements/DynamicElements/Events/EventLayout.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Anthem/Elements/DynamicElements/Events/EventLayout.php
@@ -113,7 +113,7 @@ class EventLayout extends DynamicElement
 
         $block = $this->replaceIdWithRandom($objBlock->get());
 
-        $this->createDetailPage($collectionItemsForDetailPage, $slug, $elementName);
+        $this->createDetailPage($collectionItemsForDetailPage, $slug, $elementName, $sectionData['settings']['palette'] ?? []);
         return json_encode($block);
     }
 

--- a/lib/MBMigration/Builder/Layout/Theme/Anthem/Elements/Element.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Anthem/Elements/Element.php
@@ -276,11 +276,11 @@ abstract class Element extends LayoutUtils
             throw new Exception('Element not found');
         }
 
-        $detail->item()->item(1)->item(1)->item()->item()->setting('detailButtonBgColorHex', $palette['btn-bg']);
+        $detail->item()->item(1)->item(1)->item()->item()->setting('detailButtonBgColorHex', $palette['btn-bg'] ?? '#171727');
         $detail->item()->item(1)->item(1)->item()->item()->setting('detailButtonBgColorOpacity', 1);
         $detail->item()->item(1)->item(1)->item()->item()->setting('detailButtonBgColorPalette', "");
 
-        $detail->item()->item(1)->item(1)->item()->item()->setting('hoverDetailButtonBgColorHex', $palette['btn-bg']);
+        $detail->item()->item(1)->item(1)->item()->item()->setting('hoverDetailButtonBgColorHex', $palette['btn-bg'] ?? '#171727');
         $detail->item()->item(1)->item(1)->item()->item()->setting('hoverDetailButtonBgColorOpacity', 0.75);
         $detail->item()->item(1)->item(1)->item()->item()->setting('hoverDetailButtonBgColorPalette', "");
 


### PR DESCRIPTION
…creation

The commit introduces a default color (`#171727`) for button background colors, helping prevent potential errors when appropriate color values aren't provided in the palette. Furthermore, it allows passing palette configurations to the method `createDetailPage` within the 'EventLayout' class, enabling customization of detail page elements by utilizing these settings.