### PR TITLE
Add conditional check for mediaGridContainer setting

### DIFF
--- a/lib/MBMigration/Builder/Layout/Theme/Anthem/Elements/DynamicElements/Sermons/GridMediaLayout.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Anthem/Elements/DynamicElements/Sermons/GridMediaLayout.php
@@ -113,6 +113,10 @@ class GridMediaLayout extends DynamicElement
 
         $objBlock->item()->item(1)->item()->setting('showCategoryFilter', "off");
 
+        if($sectionData['settings']['mediaGridContainer'] === false){
+            $objBlock->item()->item(1)->item()->setting('searchValue', $sectionData['settings']['containTitle']);
+        }
+
         $objBlock->item()->item(1)->item()->setting('titleColorHex', $sectionData['style']['sermon']['text'] ?? "#1e1eb7");
         $objBlock->item()->item(1)->item()->setting('titleColorOpacity', 1);
         $objBlock->item()->item(1)->item()->setting('titleColorPalette', "");


### PR DESCRIPTION
This commit introduces a conditional check for the 'mediaGridContainer' setting in the GridMediaLayout. If the setting is false, the 'searchValue' is set to the value of 'containTitle' from the section data.