### PR TITLE
Update title color source and navigation type

### DIFF
--- a/lib/MBMigration/Browser/BrowserPHP.php
+++ b/lib/MBMigration/Browser/BrowserPHP.php
@@ -77,7 +77,7 @@ class BrowserPHP implements BrowserInterface
         }
 
         \MBMigration\Core\Logger::instance()->debug('Navigate to: '.$url);
-        $this->page->navigate($url)->waitForNavigation(Page::LOAD, 60000);
+        $this->page->navigate($url)->waitForNavigation(Page::NETWORK_IDLE, 60000);
 
 
         return new BrowserPagePHP($this->page, $this->scriptPath."/Theme/".$theme."/Assets/dist");

--- a/lib/MBMigration/Builder/Layout/Theme/Anthem/Elements/DynamicElements/Sermons/GridMediaLayout.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Anthem/Elements/DynamicElements/Sermons/GridMediaLayout.php
@@ -117,11 +117,11 @@ class GridMediaLayout extends DynamicElement
             $objBlock->item()->item(1)->item()->setting('searchValue', $sectionData['settings']['containTitle']);
         }
 
-        $objBlock->item()->item(1)->item()->setting('titleColorHex', $sectionData['style']['sermon']['text'] ?? "#1e1eb7");
+        $objBlock->item()->item(1)->item()->setting('titleColorHex', $sectionData['settings']['palette']['link'] ?? "#1e1eb7");
         $objBlock->item()->item(1)->item()->setting('titleColorOpacity', 1);
         $objBlock->item()->item(1)->item()->setting('titleColorPalette', "");
 
-        $objBlock->item()->item(1)->item()->setting('hoverTitleColorHex', $sectionData['style']['sermon']['text'] ?? "#1e1eb7");
+        $objBlock->item()->item(1)->item()->setting('hoverTitleColorHex', $sectionData['settings']['palette']['link'] ?? "#1e1eb7");
         $objBlock->item()->item(1)->item()->setting('hoverTitleColorOpacity', 0.7);
         $objBlock->item()->item(1)->item()->setting('hoverTitleColorPalette', "");
 


### PR DESCRIPTION
The commit modifies the `GridMediaLayout.php` file, changing the source of `titleColorHex` and `hoverTitleColorHex` to be from 'palette' instead of 'sermon'. Also, in the `BrowserPHP.php` file, the navigation wait type was updated from 'LOAD' to 'NETWORK_IDLE'. An explicit newline was added at the end of the document as well to adhere to good coding standards.