### PR TITLE
Update settings for Sermons Detail Page

### DIFF
--- a/lib/MBMigration/Builder/Layout/Theme/Anthem/Elements/DynamicElements/Sermons/GridMediaLayout.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Anthem/Elements/DynamicElements/Sermons/GridMediaLayout.php
@@ -156,7 +156,7 @@ class GridMediaLayout extends DynamicElement
 
         $block = $this->replaceIdWithRandom($objBlock->get());
 
-        $this->createDetailPage($collectionItemsForDetailPage, $slug, $elementName, $sectionData['settings']['palette'] ?? []);
+        $this->createSermonsDetailPage($collectionItemsForDetailPage, $slug, $elementName, $sectionData['settings']['palette'] ?? []);
         return json_encode($block);
     }
 

--- a/lib/MBMigration/Builder/Layout/Theme/Anthem/Elements/DynamicElements/Sermons/ListMediaLayout.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Anthem/Elements/DynamicElements/Sermons/ListMediaLayout.php
@@ -114,7 +114,7 @@ class ListMediaLayout extends DynamicElement
 
         $block = $this->replaceIdWithRandom($objBlock->get());
 
-        $this->createDetailPage($collectionItemsForDetailPage, $slug, $elementName, $sectionData['settings']['palette'] ?? []);
+        $this->createSermonsDetailPage($collectionItemsForDetailPage, $slug, $elementName, $sectionData['settings']['palette'] ?? []);
         return json_encode($block);
     }
 

--- a/lib/MBMigration/Builder/Layout/Theme/Anthem/Elements/Element.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Anthem/Elements/Element.php
@@ -279,7 +279,7 @@ abstract class Element extends LayoutUtils
         $detail->item()->item(1)->item()->item()->item()->setting('showImage', 'off');
         $detail->item()->item(1)->item()->item()->item()->setting('showTitle', 'on');
         $detail->item()->item(1)->item()->item()->item()->setting('showDescription', 'on');
-        $detail->item()->item(1)->item()->item()->item()->setting('showSubscribeToEvent', 'off');
+        $detail->item()->item(1)->item()->item()->item()->setting('showSubscribeToEvent', 'on');
         $detail->item()->item(1)->item()->item()->item()->setting('showPreviousPage', 'off');
         $detail->item()->item(1)->item()->item()->item()->setting('showCoordinatorPhone', 'off');
         $detail->item()->item(1)->item()->item()->item()->setting('showMetaIcons', 'off');
@@ -323,13 +323,26 @@ abstract class Element extends LayoutUtils
         $detail->item()->item(1)->item()->item()->item()->setting('hoverMetaLinksColorOpacity', 0.75);
         $detail->item()->item(1)->item()->item()->item()->setting('hoverMetaLinksColorPalette', "");
 
+        $detail->item()->item(1)->item()->item()->item()->setting('subscribeEventButtonColorHex', $palette['btn-text'] ?? '#171727');
+        $detail->item()->item(1)->item()->item()->item()->setting('subscribeEventButtonColorOpacity', 1);
+        $detail->item()->item(1)->item()->item()->item()->setting('subscribeEventButtonColorPalette', "");
+
+        $detail->item()->item(1)->item()->item()->item()->setting('subscribeEventButtonBgColorHex', $palette['btn-bg'] ?? '#171727');
+        $detail->item()->item(1)->item()->item()->item()->setting('subscribeEventButtonBgColorOpacity', 1);
+        $detail->item()->item(1)->item()->item()->item()->setting('subscribeEventButtonBgColorPalette', "");
+
+        $detail->item()->item(1)->item()->item()->item()->setting('hoverSubscribeEventButtonBgColorHex', $palette['btn-bg'] ?? '#171727');
+        $detail->item()->item(1)->item()->item()->item()->setting('hoverSubscribeEventButtonBgColorOpacity', 0.75);
+        $detail->item()->item(1)->item()->item()->item()->setting('hoverSubscribeEventButtonBgColorPalette', "");
+
+
         $detail->item()->item(1)->item(1)->item()->item()->setting('showImage', 'off');
         $detail->item()->item(1)->item(1)->item()->item()->setting('showTitle', 'off');
         $detail->item()->item(1)->item(1)->item()->item()->setting('showDescription', 'off');
-        $detail->item()->item(1)->item(1)->item()->item()->setting('showSubscribeToEvent', 'on');
+        $detail->item()->item(1)->item(1)->item()->item()->setting('showSubscribeToEvent', 'off');
         $detail->item()->item(1)->item(1)->item()->item()->setting('showPreviousPage', 'on');
         $detail->item()->item(1)->item(1)->item()->item()->setting('showCoordinatorPhone', 'on');
-        $detail->item()->item(1)->item(1)->item()->item()->setting('showMetaIcons', 'on');
+        $detail->item()->item(1)->item(1)->item()->item()->setting('showMetaIcons', 'off');
         $detail->item()->item(1)->item(1)->item()->item()->setting('showGroup', 'on');
         $detail->item()->item(1)->item(1)->item()->item()->setting('showDate', 'on');
         $detail->item()->item(1)->item(1)->item()->item()->setting('showCategory', 'on');
@@ -361,6 +374,10 @@ abstract class Element extends LayoutUtils
         $detail->item()->item(1)->item(1)->item()->item()->setting('detailButtonBgColorHex', $palette['btn-bg'] ?? '#171727');
         $detail->item()->item(1)->item(1)->item()->item()->setting('detailButtonBgColorOpacity', 1);
         $detail->item()->item(1)->item(1)->item()->item()->setting('detailButtonBgColorPalette', "");
+
+        $detail->item()->item(1)->item(1)->item()->item()->setting('subscribeEventButtonColorHex', $palette['btn-text'] ?? '#171727');
+        $detail->item()->item(1)->item(1)->item()->item()->setting('subscribeEventButtonColorOpacity', 1);
+        $detail->item()->item(1)->item(1)->item()->item()->setting('subscribeEventButtonColorPalette', "");
 
         $detail->item()->item(1)->item(1)->item()->item()->setting('hoverDetailButtonBgColorHex', $palette['btn-bg'] ?? '#171727');
         $detail->item()->item(1)->item(1)->item()->item()->setting('hoverDetailButtonBgColorOpacity', 0.75);
@@ -397,25 +414,28 @@ abstract class Element extends LayoutUtils
             throw new Exception('Element not found');
         }
 
-        $detail->item()->item(1)->item()->item()->item()->setting('showImage', 'off');
+        $detail->item()->item(1)->item()->item()->item()->setting('showMediaLinksVideo', 'off');
+        $detail->item()->item(1)->item()->item()->item()->setting('showMediaLinksAudio', 'off');
+        $detail->item()->item(1)->item()->item()->item()->setting('showMediaLinksDownload', 'off');
+        $detail->item()->item(1)->item()->item()->item()->setting('showMediaLinksNotes', 'off');
+        $detail->item()->item(1)->item()->item()->item()->setting('showPreview', 'on');
+        $detail->item()->item(1)->item()->item()->item()->setting('showVideo', 'off');
+        $detail->item()->item(1)->item()->item()->item()->setting('showTitle', 'on');
         $detail->item()->item(1)->item()->item()->item()->setting('showDate', 'off');
+        $detail->item()->item(1)->item()->item()->item()->setting('showCategory', 'off');
+        $detail->item()->item(1)->item()->item()->item()->setting('showPreacher', 'off');
+        $detail->item()->item(1)->item()->item()->item()->setting('showPassage', 'off');
         $detail->item()->item(1)->item()->item()->item()->setting('showMetaHeadings', 'off');
-        $detail->item()->item(1)->item()->item()->item()->setting('showLocation', 'off');
-        $detail->item()->item(1)->item()->item()->item()->setting('showRoom', 'off');
-        $detail->item()->item(1)->item()->item()->item()->setting('showCoordinator', 'off');
-        $detail->item()->item(1)->item()->item()->item()->setting('showCoordinatorEmail', 'off');
-        $detail->item()->item(1)->item()->item()->item()->setting('showCost', 'off');
-        $detail->item()->item(1)->item()->item()->item()->setting('showWebsite', 'off');
-        $detail->item()->item(1)->item()->item()->item()->setting('calendarViewOrder', 'off');
-        $detail->item()->item(1)->item()->item()->item()->setting('showRegistration', 'off');
-        $detail->item()->item(1)->item()->item()->item()->setting('showSubscribeToEvent', 'off');
-        $detail->item()->item(1)->item()->item()->item()->setting('showCoordinatorPhone', 'off');
-        $detail->item()->item(1)->item()->item()->item()->setting('showGroup', 'off');
         $detail->item()->item(1)->item()->item()->item()->setting('showPreviousPage', 'off');
 
         $detail->item()->item(1)->item()->item()->item()->setting('titleColorHex', $palette['text'] ?? '#171727');
+        $detail->item()->item(1)->item()->item()->item()->setting('titleTypographyFontStyle', 'heading3');
         $detail->item()->item(1)->item()->item()->item()->setting('titleColorOpacity', 1);
-        $detail->item()->item(1)->item()->item()->item()->setting('titleColorPalette', '');
+        $detail->item()->item(1)->item()->item()->item()->setting('titleColorPalette', "");
+
+        $detail->item()->item(1)->item()->item()->item()->setting('previewColorHex', $palette['text'] ?? '#171727');
+        $detail->item()->item(1)->item()->item()->item()->setting('previewColorOpacity', 1);
+        $detail->item()->item(1)->item()->item()->item()->setting('previewColorPalette', "");
 
         $detail->item()->item(1)->item()->item()->item()->setting('colorHex', $palette['text'] ?? '#171727');
         $detail->item()->item(1)->item()->item()->item()->setting('colorOpacity', 1);
@@ -425,41 +445,34 @@ abstract class Element extends LayoutUtils
         $detail->item()->item(1)->item()->item()->item()->setting('previewColorOpacity', 1);
         $detail->item()->item(1)->item()->item()->item()->setting('previewColorPalette', '');
 
-        $detail->item()->item(1)->item()->item()->item()->setting('detailButtonBgColorHex', $palette['btn-bg'] ?? '#171727');
-        $detail->item()->item(1)->item()->item()->item()->setting('detailButtonBgColorOpacity', 1);
-        $detail->item()->item(1)->item()->item()->item()->setting('detailButtonBgColorPalette', "");
-
-        $detail->item()->item(1)->item()->item()->item()->setting('hoverDetailButtonBgColorHex', $palette['btn-bg'] ?? '#171727');
-        $detail->item()->item(1)->item()->item()->item()->setting('hoverDetailButtonBgColorOpacity', 0.75);
-        $detail->item()->item(1)->item()->item()->item()->setting('hoverDetailButtonBgColorPalette', "");
-
-        $detail->item()->item(1)->item()->item()->item()->setting('metaLinksColorHex', $palette['link'] ?? '#171727');
-        $detail->item()->item(1)->item()->item()->item()->setting('metaLinksColorOpacity', 1);
-        $detail->item()->item(1)->item()->item()->item()->setting('metaLinksColorPalette', "");
-
-        $detail->item()->item(1)->item()->item()->item()->setting('hoverMetaLinksColorHex', $palette['link'] ?? '#171727');
-        $detail->item()->item(1)->item()->item()->item()->setting('hoverMetaLinksColorOpacity', 0.75);
-        $detail->item()->item(1)->item()->item()->item()->setting('hoverMetaLinksColorPalette', "");
-
-        $detail->item()->item(1)->item(1)->item()->item()->setting('showImage', 'off');
+        $detail->item()->item(1)->item(1)->item()->item()->setting('showMediaLinksVideo', 'off');
+        $detail->item()->item(1)->item(1)->item()->item()->setting('showMediaLinksAudio', 'off');
+        $detail->item()->item(1)->item(1)->item()->item()->setting('showMediaLinksDownload', 'on');
+        $detail->item()->item(1)->item(1)->item()->item()->setting('showMediaLinksNotes', 'on');
+        $detail->item()->item(1)->item(1)->item()->item()->setting('showPreview', 'off');
+        $detail->item()->item(1)->item(1)->item()->item()->setting('showVideo', 'off');
         $detail->item()->item(1)->item(1)->item()->item()->setting('showTitle', 'off');
-        $detail->item()->item(1)->item(1)->item()->item()->setting('showDescription', 'off');
-        $detail->item()->item(1)->item(1)->item()->item()->setting('showSubscribeToEvent', 'on');
-        $detail->item()->item(1)->item(1)->item()->item()->setting('showPreviousPage', 'on');
-        $detail->item()->item(1)->item(1)->item()->item()->setting('showMetaIcons', 'on');
-        $detail->item()->item(1)->item(1)->item()->item()->setting('showGroup', 'off');
-        $detail->item()->item(1)->item(1)->item()->item()->setting('showCoordinatorPhone', 'off');
-        $detail->item()->item(1)->item(1)->item()->item()->setting('showWebsite', 'off');
-        $detail->item()->item(1)->item(1)->item()->item()->setting('calendarViewOrder', 'off');
-        $detail->item()->item(1)->item(1)->item()->item()->setting('showRegistration', 'on');
+        $detail->item()->item(1)->item(1)->item()->item()->setting('showDate', 'off');
+        $detail->item()->item(1)->item(1)->item()->item()->setting('showCategory', 'off');
+        $detail->item()->item(1)->item(1)->item()->item()->setting('showPreacher', 'off');
+        $detail->item()->item(1)->item(1)->item()->item()->setting('showPassage', 'off');
+        $detail->item()->item(1)->item(1)->item()->item()->setting('showMetaHeadings', 'off');
+        $detail->item()->item(1)->item(1)->item()->item()->setting('showPreviousPage', 'off');
+        $detail->item()->item(1)->item(1)->item()->item()->setting('showGroup', 'on');
+        $detail->item()->item(1)->item(1)->item()->item()->setting('showSeries', 'on');
 
         $detail->item()->item(1)->item(1)->item()->item()->setting('colorHex', $palette['text'] ?? '#171727');
         $detail->item()->item(1)->item(1)->item()->item()->setting('colorOpacity', 1);
         $detail->item()->item(1)->item(1)->item()->item()->setting('colorPalette', "");
 
-        $detail->item()->item(1)->item(1)->item()->item()->setting('dateColorHex', $palette['text'] ?? '#171727');
-        $detail->item()->item(1)->item(1)->item()->item()->setting('dateColorOpacity', 1);
-        $detail->item()->item(1)->item(1)->item()->item()->setting('dateColorPalette', "");
+        $detail->item()->item(1)->item(1)->item()->item()->setting('titleColorHex', $palette['text'] ?? '#171727');
+        $detail->item()->item(1)->item(1)->item()->item()->setting('titleTypographyFontStyle', 'heading3');
+        $detail->item()->item(1)->item(1)->item()->item()->setting('titleColorOpacity', 1);
+        $detail->item()->item(1)->item(1)->item()->item()->setting('titleColorPalette', "");
+
+        $detail->item()->item(1)->item(1)->item()->item()->setting('previewColorHex', $palette['text'] ?? '#171727');
+        $detail->item()->item(1)->item(1)->item()->item()->setting('previewColorOpacity', 1);
+        $detail->item()->item(1)->item(1)->item()->item()->setting('previewColorPalette', "");
 
         $detail->item()->item(1)->item(1)->item()->item()->setting('metaLinksColorHex', $palette['link'] ?? '#171727');
         $detail->item()->item(1)->item(1)->item()->item()->setting('metaLinksColorOpacity', 1);
@@ -477,13 +490,6 @@ abstract class Element extends LayoutUtils
         $detail->item()->item(1)->item(1)->item()->item()->setting('hoverDetailButtonBgColorOpacity', 0.75);
         $detail->item()->item(1)->item(1)->item()->item()->setting('hoverDetailButtonBgColorPalette', "");
 
-        $detail->item()->item(1)->item(1)->item()->item()->setting('subscribeEventButtonBgColorHex', $palette['btn-bg'] ?? '#171727');
-        $detail->item()->item(1)->item(1)->item()->item()->setting('subscribeEventButtonBgColorOpacity', 1);
-        $detail->item()->item(1)->item(1)->item()->item()->setting('subscribeEventButtonBgColorPalette', "");
-
-        $detail->item()->item(1)->item(1)->item()->item()->setting('hoverSubscribeEventButtonBgColorHex', $palette['btn-bg'] ?? '#171727');
-        $detail->item()->item(1)->item(1)->item()->item()->setting('hoverSubscribeEventButtonBgColorOpacity', 0.75);
-        $detail->item()->item(1)->item(1)->item()->item()->setting('hoverSubscribeEventButtonBgColorPalette', "");
 
         $itemsData['items'][] = $detail->get();
 


### PR DESCRIPTION
The commit involves the renaming of createDetailPage to createSermonsDetailPage for clarity. Changes in settings of the detail page include turning on 'showSubscribeToEvent' option, adding 'subscribeEventButton' options and altering visibility of various elements. This provides a more detailed and specific configuration for Sermons Detail Page.