### PR TITLE
Add button selector in FourHorizontalText component

### DIFF
--- a/lib/MBMigration/Builder/Layout/Common/Concern/RichTextAble.php
+++ b/lib/MBMigration/Builder/Layout/Common/Concern/RichTextAble.php
@@ -271,7 +271,7 @@ trait RichTextAble
         $dom = new DOMDocument();
         $dom->loadHTML(
             "<!DOCTYPE html><html><head><meta http-equiv=\"content-type\" content=\"text/html; charset=utf-8\"></head><body>{$html}</body></html>",
-            LIBXML_BIGLINES | LIBXML_NOBLANKS | LIBXML_NONET | LIBXML_NOERROR | LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD | LIBXML_PARSEHUGE
+            LIBXML_NOWARNING | LIBXML_BIGLINES | LIBXML_NOBLANKS | LIBXML_NONET | LIBXML_NOERROR | LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD | LIBXML_PARSEHUGE
         );
 
         $iframes = $dom->getElementsByTagName('iframe');

--- a/lib/MBMigration/Builder/Layout/Theme/Ember/Elements/FourHorizontalText.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Ember/Elements/FourHorizontalText.php
@@ -41,6 +41,8 @@ class FourHorizontalText extends AbstractElement
             $this->handleRichTextItem($tmpElementContext, $this->browserPage);
             $tmpElementContext = $data->instanceWithBrizyComponentAndMBSection($bodies[$i], $brizyColumn);
             $this->handleRichTextItem($tmpElementContext, $this->browserPage);
+            $buttonSelector = $mbSection['sectionId'];
+            $this->handleRichTextItem($tmpElementContext, $this->browserPage, "[data-id='$buttonSelector'] .group-$i > a");
             $columns[] = $brizyColumn;
         }
         $brizySection->getItemValueWithDepth(0,0)->add_items($columns);


### PR DESCRIPTION
A button selector variable has been introduced in the FourHorizontalText component to handle the rich text item. Additionally, the HTML parsing flags in the RichTextAble class have been updated to include LIBXML_NOWARNING, helping to suppress warning messages during the DOM creation process.