### PR TITLE
fix(menu): menu hover and mobile menu icon color

### DIFF
--- a/packages/elements/src/Menu/getMenuItem.ts
+++ b/packages/elements/src/Menu/getMenuItem.ts
@@ -1,4 +1,5 @@
 import { getModel } from "./utils/getModel";
+import { toMenuItemElement } from "./utils/toMenuItemElement";
 import {
   MenuItemElement,
   MenuItemEntry,
@@ -11,13 +12,13 @@ interface MenuItemData {
   item: MenuItemElement;
   itemBg: MenuItemElement;
   itemPadding: MenuItemElement;
-  itemMobile?: MenuItemElement;
+  itemMobileIcon?: MenuItemElement;
   families: Record<string, string>;
   defaultFamily: string;
 }
 
 const getV = (entry: MenuItemData) => {
-  const { item, itemBg, itemPadding, itemMobile, families, defaultFamily } =
+  const { item, itemBg, itemPadding, itemMobileIcon, families, defaultFamily } =
     entry;
 
   const model = {
@@ -42,7 +43,9 @@ const getV = (entry: MenuItemData) => {
 
   const bgModel = {
     "menu-bg-color-hex": undefined,
-    "menu-bg-color-opacity": 1
+    "menu-bg-color-opacity": 1,
+    "m-menu-bg-color-hex": undefined,
+    "m-menu-bg-color-opacity": 1
   };
 
   const bgV = getModel({
@@ -63,26 +66,26 @@ const getV = (entry: MenuItemData) => {
     defaultFamily: defaultFamily
   });
 
-  const mobileModel = {
+  const mobileIconV = {};
+
+  const mobileIconModel = {
     "m-menu-icon-color-hex": undefined,
     "m-menu-icon-color-opacity": undefined
   };
 
-  const mobileV = {};
-
-  if (itemMobile) {
+  if (itemMobileIcon) {
     Object.assign(
-      mobileV,
+      mobileIconV,
       getModel({
-        node: itemMobile,
-        modelDefaults: mobileModel,
+        node: itemMobileIcon,
+        modelDefaults: mobileIconModel,
         families: families,
         defaultFamily: defaultFamily
       })
     );
   }
 
-  return { ...v, ...mMenu, ...bgV, ...paddingV, ...mobileV };
+  return { ...v, ...mMenu, ...bgV, ...paddingV, ...mobileIconV };
 };
 
 const getHoverV = (entry: MenuItemData) => {
@@ -90,7 +93,9 @@ const getHoverV = (entry: MenuItemData) => {
 
   const model = {
     "hover-color-hex": undefined,
-    "hover-color-opacity": undefined
+    "hover-color-opacity": 1,
+    "active-color-hex": undefined,
+    "active-color-opacity": 1
   };
 
   const v = getModel({
@@ -100,6 +105,7 @@ const getHoverV = (entry: MenuItemData) => {
     defaultFamily: defaultFamily
   });
 
+  const mMenu = prefixed(v, "mMenu");
   const bgModel = {
     "hover-menu-bg-color-hex": undefined,
     "hover-menu-bg-color-opacity": undefined
@@ -111,7 +117,7 @@ const getHoverV = (entry: MenuItemData) => {
     families: families,
     defaultFamily: defaultFamily
   });
-  return { ...v, ...bgV };
+  return { ...v, ...bgV, ...mMenu };
 };
 
 const getMenuItem = (entry: MenuItemEntry): Output => {
@@ -129,7 +135,7 @@ const getMenuItem = (entry: MenuItemEntry): Output => {
   const itemPaddingElement = document.querySelector(
     itemPaddingSelector.selector
   );
-  let itemMobileElement;
+  let itemMobileElement = null;
 
   if (itemMobileSelector) {
     itemMobileElement = document.querySelector(itemMobileSelector.selector);
@@ -151,25 +157,21 @@ const getMenuItem = (entry: MenuItemEntry): Output => {
     };
   }
 
-  const item = { item: itemElement, pseudoEl: itemSelector.pseudoEl };
+  const item = toMenuItemElement({
+    node: itemElement,
+    selector: itemSelector,
+    targetSelector: "#main-navigation li:not(.selected) > a"
+  }) ?? { item: itemElement, pseudoEl: itemSelector.pseudoEl };
   const itemBg = { item: itemBgElement, pseudoEl: itemBgSelector.pseudoEl };
   const itemPadding = {
     item: itemPaddingElement,
     pseudoEl: itemPaddingSelector.pseudoEl
   };
-  let itemMobile;
-
-  if (itemMobileElement) {
-    const mobileNavButton =
-      itemMobileElement.querySelector("#mobile-nav-button");
-
-    if (mobileNavButton) {
-      itemMobile = {
-        item: mobileNavButton,
-        pseudoEl: itemSelector.pseudoEl
-      };
-    }
-  }
+  const itemMobileIcon = toMenuItemElement({
+    node: itemMobileElement,
+    selector: itemMobileSelector,
+    targetSelector: ".mobile-nav-icon > .first"
+  });
 
   let data = {};
 
@@ -178,7 +180,7 @@ const getMenuItem = (entry: MenuItemEntry): Output => {
       item,
       itemBg,
       itemPadding,
-      itemMobile,
+      itemMobileIcon,
       families,
       defaultFamily
     });

--- a/packages/elements/src/Menu/getSubMenuItem.ts
+++ b/packages/elements/src/Menu/getSubMenuItem.ts
@@ -1,4 +1,5 @@
 import { getModel } from "./utils/getModel";
+import { toMenuItemElement } from "./utils/toMenuItemElement";
 import {
   MenuItemElement,
   MenuItemEntry,
@@ -76,7 +77,11 @@ const getHoverV = (entry: MenuItemData) => {
     families: families,
     defaultFamily: defaultFamily
   });
-  return { ...prefixed(v, "hoverSubMenu"), ...prefixed(bgV, "hoverSubMenu") };
+  return {
+    ...prefixed(v, "hoverSubMenu"),
+    ...prefixed(v, "activeSubMenu"),
+    ...prefixed(bgV, "hoverSubMenu")
+  };
 };
 
 const getSubMenuItem = (entry: MenuItemEntry): Output => {
@@ -97,11 +102,16 @@ const getSubMenuItem = (entry: MenuItemEntry): Output => {
   }
 
   const item = { item: itemElement, pseudoEl: itemSelector.pseudoEl };
+  const itemHover = toMenuItemElement({
+    node: itemElement,
+    selector: itemSelector,
+    targetSelector: "li > a"
+  }) ?? { item: itemElement, pseudoEl: itemSelector.pseudoEl };
   const itemBg = { item: itemBgElement, pseudoEl: itemBgSelector.pseudoEl };
 
   let data = {};
   if (!hover) data = getV({ item, itemBg, families, defaultFamily });
-  else data = getHoverV({ item, itemBg, families, defaultFamily });
+  else data = getHoverV({ item: itemHover, itemBg, families, defaultFamily });
 
   return createData({ data });
 };

--- a/packages/elements/src/Menu/utils/getModel.ts
+++ b/packages/elements/src/Menu/utils/getModel.ts
@@ -72,35 +72,42 @@ export const getModel = (data: Model) => {
         } else {
           // Remove 'px' and any extra whitespace
           const letterSpacingValue = `${value}`.replace(/px/g, "").trim();
-          Object.assign(dic, dicKeyForDevices(key, parseInt(`${styles[key]}`)));
-          dicKeyForDevices(key, +letterSpacingValue);
+          Object.assign(dic, dicKeyForDevices(key, letterSpacingValue));
         }
         break;
       }
       case "hover-color-hex":
       case "color-hex":
-      case "m-menu-icon-color-hex": {
+      case "active-color-hex": {
         const toHex = parseColorString(`${styles["color"]}`);
         dic[toCamelCase(key)] = toHex?.hex ?? "#ffffff";
         break;
       }
       case "hover-color-opacity":
       case "color-opacity":
-      case "m-menu-icon-color-opacity": {
+      case "active-color-opacity": {
         const toHex = parseColorString(`${styles["color"]}`);
-        dic[toCamelCase(key)] = toHex?.opacity ?? 1;
-        dic[toCamelCase(key)] = styles["opacity"] ?? undefined;
+        const opacity = isNaN(+styles.opacity) ? 1 : styles.opacity;
+
+        dic[toCamelCase(key)] = +(toHex?.opacity ?? opacity);
         break;
       }
       case "bg-color-hex":
-      case "menu-bg-color-hex": {
+      case "menu-bg-color-hex":
+      case "m-menu-icon-color-hex":
+      case "m-menu-bg-color-hex": {
         const toHex = parseColorString(`${styles["background-color"]}`);
         dic[toCamelCase(key)] = toHex?.hex ?? "#ffffff";
         break;
       }
-      case "bg-color-opacity": {
+      case "bg-color-opacity":
+      case "menu-bg-color-opacity":
+      case "m-menu-icon-color-opacity":
+      case "m-menu-bg-color-opacity": {
         const toHex = parseColorString(`${styles["background-color"]}`);
-        dic[toCamelCase(key)] = toHex?.opacity ?? 1;
+        const opacity = isNaN(+styles.opacity) ? 1 : styles.opacity;
+
+        dic[toCamelCase(key)] = +(toHex?.opacity ?? opacity);
         break;
       }
       default: {

--- a/packages/elements/src/Menu/utils/toMenuItemElement.ts
+++ b/packages/elements/src/Menu/utils/toMenuItemElement.ts
@@ -1,0 +1,33 @@
+import { MenuItemSelector } from "types/type";
+
+interface ToMenuItemElement {
+  node: Element | null;
+  selector?: MenuItemSelector;
+  targetSelector: string;
+}
+
+interface ToMenuItemElementRes {
+  item: Element;
+  pseudoEl: string;
+}
+
+export const toMenuItemElement = ({
+  node,
+  selector,
+  targetSelector
+}: ToMenuItemElement): ToMenuItemElementRes | undefined => {
+  if (!selector || !node) {
+    return;
+  }
+
+  const targetElement = node.querySelector(targetSelector);
+
+  if (targetElement) {
+    return {
+      item: targetElement,
+      pseudoEl: selector.pseudoEl
+    };
+  }
+
+  return;
+};


### PR DESCRIPTION
| Q  | A |
| ------------- | ------------- |
| Screenshot  | N/A |
| Related tickets | https://github.com/bagrinsergiu/MB-Support/issues/344 |


> 1. Mobile - can the menu icon be white, so it matches the clover example? It's not really visible with the current color: https://prnt.sc/X97gTOsjfR9t @zeleniucvladislav
![2024-08-06_16-11](https://github.com/user-attachments/assets/eac4d413-a209-49f1-b879-3ba3122d5349)


>2. On the clover site, the selected main navigation item shows the hover color as the active color. Can we do the same with the hover/active state on the Brizy site? @zeleniucvladislav
![2024-08-06_16-45](https://github.com/user-attachments/assets/708caab5-8522-4fdf-b0b6-c6e8c186069a)

> 3. For the nav on this site, the hover/active color should be white. The white color is showing on hover for the main nav items, but not for the dropdown. @zeleniucvladislav
![2024-08-07_15-24](https://github.com/user-attachments/assets/f7249937-d896-42b8-adfd-d05199c26469)

![2024-08-07_16-18](https://github.com/user-attachments/assets/9768ac0c-306a-4f2d-9f25-53d4bfd6c87a)










>  2. 2. The menu items aren't visible: https://prnt.sc/OqO1bZwq2T0q, https://timberwoodchurch-31706.mydraftsite.cloud/ @zeleniucvladislav
![2024-08-06_17-46](https://github.com/user-attachments/assets/be7305c0-a78b-4d38-934e-a28f32b541fb)
