### PR TITLE
fix(menu) : added tablet/mobile mMenu colorhex

### DIFF
--- a/packages/elements/src/Menu/getMenuItem.ts
+++ b/packages/elements/src/Menu/getMenuItem.ts
@@ -6,6 +6,7 @@ import {
   Output
 } from "elements/src/types/type";
 import { createData } from "elements/src/utils/getData";
+import { dicKeyForDevices } from "utils/src/dicKeyForDevices";
 import { prefixed } from "utils/src/models/prefixed";
 
 interface MenuItemData {
@@ -48,6 +49,14 @@ const getV = (entry: MenuItemData) => {
     defaultFamily: defaultFamily
   });
   const mMenu = prefixed(v, "mMenu");
+  Object.assign(
+    mMenu,
+    dicKeyForDevices("m-menu-color-hex", mMenu["mMenuColorHex"])
+  );
+  Object.assign(
+    mMenu,
+    dicKeyForDevices("m-menu-color-opacity", mMenu["mMenuColorOpacity"])
+  );
 
   const bgModel = {
     "menu-bg-color-hex": undefined,


### PR DESCRIPTION
| Q  | A |
| ------------- | ------------- |
| Screenshot  |  ![2024-09-09_11-25](https://github.com/user-attachments/assets/f6db2cb2-1cb7-4c22-b249-2308cf2368a3)|
| Related tickets | https://github.com/bagrinsergiu/MB-Support/issues/389 |

Related to : 
>  2. The mobile menu items need to be a lighter color: https://prnt.sc/HBJfNwZ8QIW0. See the current clover site: https://prnt.sc/D54gOIsS-vpA