### PR TITLE
fix(menu): item spacing too small

### DIFF
--- a/packages/elements/src/Menu/utils/getModel.ts
+++ b/packages/elements/src/Menu/utils/getModel.ts
@@ -51,8 +51,10 @@ export const getModel = (data: Model) => {
         break;
       }
       case "item-padding": {
-        dic[toCamelCase(key)] = parseInt(`${styles["padding-left"]}`); // we naively assume the padding are equal
-        dic["itemPaddingSuffix"] = "px"; // we naively assume the padding are equal
+        const value = parseInt(`${styles["padding-left"]}`) * 2;
+
+        dic[toCamelCase(key)] = value;
+        dic["itemPaddingSuffix"] = "px";
         break;
       }
       case "line-height": {


### PR DESCRIPTION
| Q  | A |
| ------------- | ------------- |
| Screenshot  | N/A |
| Related tickets | https://github.com/bagrinsergiu/MB-Support/issues/344 |


> For for top/main menu bar on desktop, I'm still seeing the tighter spacing here: https://prnt.sc/S-MQSjcmh2d-. It looks like this is still showing at 7.5px for both left/right margin. Can we change this to 10px? I think that should be fine.


Brizy item spacing 15px result in left 7.5 and right 7.5
![2024-09-10_11-42](https://github.com/user-attachments/assets/d8dbd7d4-449a-498c-a172-2cc6ffd4f353)


Ministrybrands ahs both spacing 15px on left and right 
![2024-09-10_11-43](https://github.com/user-attachments/assets/bdc264ac-a08d-4efa-b08e-c9599217dc57)

### Changelog
* Fixed: Menu item spacing incorrect value




