### PR TITLE
Update color palette keys in EventLayout

### DIFF
--- a/lib/MBMigration/Builder/Layout/Common/Element/Events/EventLayout.php
+++ b/lib/MBMigration/Builder/Layout/Common/Element/Events/EventLayout.php
@@ -119,11 +119,11 @@ abstract class EventLayout extends AbstractElement
             'calendarDaysBgColorOpacity' => 1,
             'calendarDaysBgColorPalette' => '',
 
-            'calendarDaysBgColorHex' => $sectionPalette['btn-bg'] ?? $sectionPalette['btn'],
+            'calendarDaysBgColorHex' => $sectionPalette['bg'],
             'calendarHeadingColorOpacity' => 1,
             'calendarHeadingColorPalette' => '',
 
-            'calendarDaysColorHex' => $sectionPalette['btn-text'],
+            'calendarDaysColorHex' => $sectionPalette['text'],
             'calendarDaysColorOpacity' => 1,
             'calendarDaysColorPalette' => '',
 


### PR DESCRIPTION
Replaced 'btn-bg' and 'btn' with 'bg' for the calendar background color hex and 'btn-text' with 'text' for the calendar days color hex. This aligns with the new section palette structure.