### PR TITLE
Handle empty gallery list in PageController.

### DIFF
--- a/lib/MBMigration/Builder/PageController.php
+++ b/lib/MBMigration/Builder/PageController.php
@@ -374,27 +374,32 @@ class PageController
 
                 switch ($section['category']) {
                     case 'gallery':
-                        $itemsSubGallery = [
-                            'sectionId' => $section['id'],
-                            'typeSection' => 'sub-gallery-layout',
-                            'position' => $section['position'],
-                            'category' => $section['category'],
-                            'settings' => $section['settings'],
-                            'head' => [],
-                            'slide' => [],
-                            'items' => [],
-                        ];
+                        if (!empty($sectionItems['list'])) {
+                            $itemsSubGallery = [
+                                'sectionId' => $section['id'],
+                                'typeSection' => 'sub-gallery-layout',
+                                'position' => $section['position'],
+                                'category' => $section['category'],
+                                'settings' => $section['settings'],
+                                'head' => [],
+                                'slide' => [],
+                                'items' => [],
+                            ];
 
-                        foreach ($sectionItems as $key => $Item) {
-                            if ($key === 'slide') {
-                                $items['slide'] = array_merge($items['slide'], $Item);
-                                $sections[] = $items;
-                            } else if ($key === 'list') {
-                                $position++;
-                                $itemsSubGallery['position'] = $position;
-                                $itemsSubGallery['items'] = array_merge($items['items'], $Item);
-                                $sections[] = $itemsSubGallery;
+                            foreach ($sectionItems as $key => $Item) {
+                                if ($key === 'slide') {
+                                    $items['slide'] = array_merge($items['slide'], $Item);
+                                    $sections[] = $items;
+                                } else if ($key === 'list') {
+                                    $position++;
+                                    $itemsSubGallery['position'] = $position;
+                                    $itemsSubGallery['items'] = array_merge($items['items'], $Item);
+                                    $sections[] = $itemsSubGallery;
+                                }
                             }
+                        } else {
+                            $items['slide'] = $sectionItems['slide'];
+                            $sections[] = $items;
                         }
                         break;
                     default:


### PR DESCRIPTION
Added a check for empty gallery lists to prevent errors when no items are found. This ensures the 'slide' key is handled properly even if the 'list' key doesn't exist, improving data integrity and avoiding potential crashes in the gallery section rendering.