### PR TITLE
Add sermon detail constants for page and slug names

### DIFF
--- a/lib/MBMigration/Builder/Layout/Common/Element/Sermons/MediaLayout.php
+++ b/lib/MBMigration/Builder/Layout/Common/Element/Sermons/MediaLayout.php
@@ -22,6 +22,9 @@ abstract class MediaLayout extends AbstractElement
     use BrizyQueryBuilderAware;
     use SlugAble;
 
+    const DETAILS_PAGE_NAME = 'Sermon Detail';
+    const DETAILS_SLUG_NAME = 'sermon-detail';
+
     /**
      * @param $brizyKit
      * @param BrowserPageInterface $browserPage
@@ -208,8 +211,8 @@ abstract class MediaLayout extends AbstractElement
             $detailCollectionItem = $this->createDetailsCollectionItem(
                 $collectionTypeUri,
                 $detailsSection,
-                'media-detail',
-                'Media Detail'
+                self::DETAILS_SLUG_NAME,
+                self::DETAILS_PAGE_NAME,
             );
 
             $placeholder = base64_encode('{{ brizy_dc_url_post entityId="' . $detailCollectionItem['id'] . '" }}');


### PR DESCRIPTION
This update introduces `DETAILS_PAGE_NAME` and `DETAILS_SLUG_NAME` constants to replace hardcoded values in the `MediaLayout` class. This change enhances code maintainability and readability by using named constants for repeated strings.