### PR TITLE
Fix colorHex fallback and add active menu styles

### DIFF
--- a/lib/MBMigration/Builder/Layout/Common/Element/Sermons/MediaLayout.php
+++ b/lib/MBMigration/Builder/Layout/Common/Element/Sermons/MediaLayout.php
@@ -236,7 +236,7 @@ abstract class MediaLayout extends AbstractElement
 
                 'showCategoryFilter' => 'off',
 
-                'colorHex' =>  $colorStyles['color-text-header']['color'] ?? "#ebeff2",
+                'colorHex' =>  $colorStyles['color-text-header']['color'] ?? $colorStyles['color-text-header'],
                 'colorOpacity' => $colorStyles['color-text-header']['opacity'] ?? 1,
                 'colorPalette' => "",
 

--- a/lib/MBMigration/Builder/Layout/Theme/Anthem/Elements/Head.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Anthem/Elements/Head.php
@@ -111,6 +111,19 @@ class Head extends HeadElement
             'mobileHeightSuffix' => '%',
         ];
 
+        $activeItemMenuOptions = [
+            'activeMenuBorderStyle' => 'solid',
+            'activeMenuBorderColorHex' => '#000000',
+            'activeMenuBorderColorOpacity' => 0.02,
+            'activeMenuBorderColorPalette' => '',
+            'activeMenuBorderWidthType' => 'ungrouped',
+            'activeMenuBorderWidth' => 3,
+            'activeMenuBorderTopWidth' => 0,
+            'activeMenuBorderRightWidth' => 0,
+            'activeMenuBorderBottomWidth' => 3,
+            'activeMenuBorderLeftWidth' => 0,
+        ];
+
         $sectionlogoOptions = [
             'horizontalAlign' => 'center',
             'mobileHorizontalAlign' => 'left',
@@ -165,6 +178,13 @@ class Head extends HeadElement
 
 
         foreach ($this->getPropertiesIconMenuItem() as $logoOption => $value) {
+            $nameOption = 'set_'.$logoOption;
+            $brizySection->getItemWithDepth(0, 0, 0, 1, 0)
+                ->getValue()
+                ->$nameOption($value);
+        }
+
+        foreach ($activeItemMenuOptions as $logoOption => $value) {
             $nameOption = 'set_'.$logoOption;
             $brizySection->getItemWithDepth(0, 0, 0, 1, 0)
                 ->getValue()


### PR DESCRIPTION
Updated MediaLayout to correct colorHex fallback value to handle opacity. Introduced new style options for active menu items in Head.php, including border styles and colors.