### PR TITLE
Fix autoplay condition in GalleryLayoutElement

### DIFF
--- a/lib/MBMigration/Builder/Layout/Common/Elements/Gallery/GalleryLayoutElement.php
+++ b/lib/MBMigration/Builder/Layout/Common/Elements/Gallery/GalleryLayoutElement.php
@@ -50,7 +50,7 @@ abstract class GalleryLayoutElement extends AbstractElement
 
         $arrows = $mbSection['settings']['sections']['gallery']['arrows'] ?? true;
         $markers = $mbSection['settings']['sections']['gallery']['markers'] ?? true;
-        $autoplay = count($mbSection['items']) <= 1 ? false : $declaredAutoplay;
+        $autoplay = count($mbSection['slide']) <= 1 ? false : $declaredAutoplay;
         //$animation = $mbSection['settings']['sections']['gallery']['transition'] ?? 'Slide';
 
 //        $slideDuration = 0.5;


### PR DESCRIPTION
Changed condition to check 'slide' count instead of 'items' count to determine autoplay behavior. This ensures correct autoplay setting when there is only one slide.