### PR TITLE
Fix active pagination color opacity assignment

### DIFF
--- a/lib/MBMigration/Builder/Layout/Common/Elements/Sermons/MediaLayoutElement.php
+++ b/lib/MBMigration/Builder/Layout/Common/Elements/Sermons/MediaLayoutElement.php
@@ -269,7 +269,7 @@ abstract class MediaLayoutElement extends AbstractElement
                 'paginationColorPalette' => '',
 
                 'activePaginationColorHex' => $colorStyles['pagination-active']['color'] ?? $colorStyles['pagination-active'],
-                'activePaginationColorOpacity' => floatval($colorStyles['pagination-active']['opacity'] ?? $colorStyles['opacity-pagination-active']),
+                'activePaginationColorOpacity' => floatval($colorStyles['opacity-pagination-active'] ?? $colorStyles['pagination-active']['opacity']),
                 'activePaginationColorPalette' => '',
 
                 'hoverPaginationColorHex' => $colorStyles['pagination-normal']['color'] ?? $colorStyles['pagination-normal'],


### PR DESCRIPTION
Correct the key reference for 'activePaginationColorOpacity' to ensure the opacity value is accurately retrieved. This change swaps the order of the fallback values, fixing potential issues with opacity settings in pagination.