### PR TITLE
Adjust background opacity for high-opacity images

### DIFF
--- a/lib/MBMigration/Builder/Layout/Common/Concern/SectionStylesAble.php
+++ b/lib/MBMigration/Builder/Layout/Common/Concern/SectionStylesAble.php
@@ -178,6 +178,12 @@ trait SectionStylesAble
         if ($this->hasImageBackground($mbSectionItem)) {
             $background = $mbSectionItem['settings']['sections']['background'];
             if (isset($background['filename']) && isset($background['photo'])) {
+
+                if($background['opacity']>=0.9)
+                {
+                    $background['opacity'] = 0.6;
+                }
+
                 $brizySection->getValue()
                     ->set_bgImageFileName($background['filename'])
                     ->set_bgImageSrc($background['photo'])


### PR DESCRIPTION
If the background opacity is 0.9 or greater, set it to 0.6 to ensure visual consistency in sections. This change improves readability and design aesthetics when dealing with images that have high opacity values.