### PR TITLE
Handle new window option in handleLink method

### DIFF
--- a/lib/MBMigration/Builder/Layout/Common/Concern/RichTextAble.php
+++ b/lib/MBMigration/Builder/Layout/Common/Concern/RichTextAble.php
@@ -283,6 +283,12 @@ trait RichTextAble
 
     private function handleLink($mbSectionItem, $brizyComponent)
     {
+        if ($mbSectionItem['new_window']) {
+            $mbSectionItem['new_window'] = 'on';
+        } else {
+            $mbSectionItem['new_window'] = 'off';
+        }
+
         if ($mbSectionItem['link'] != '') {
             if ($this->findTag($mbSectionItem['link'], 'iframe')) {
                 $popupFromKit = $this->globalBrizyKit['popup']['popup--embedCode'];


### PR DESCRIPTION
Previously, the new window option for links was not processed. This update ensures that the 'new_window' attribute is properly set to 'on' or 'off' based on its value.