### PR TITLE
Add mobile size for single item rows in GridLayoutElement

### DIFF
--- a/lib/MBMigration/Builder/Layout/Common/Elements/Text/GridLayoutElement.php
+++ b/lib/MBMigration/Builder/Layout/Common/Elements/Text/GridLayoutElement.php
@@ -54,6 +54,10 @@ abstract class GridLayoutElement extends AbstractElement
             $rowWidth = (int)( (100/$this->getItemsPerRow()) * $itemCount );
             $brizySectionRow->getValue()->set_size($rowWidth);
 
+            if ($itemCount === 1) {
+                $brizySectionRow->getValue()->set_mobileSize(100);
+            }
+
             foreach ($row as $item) {
 
                 $dataIdSelector = '[data-id="'.($item['sectionId'] ?? $item['id']).'"]';


### PR DESCRIPTION
Adjust the mobile size to 100% when there's only one item in a row. This ensures a full-width display on mobile devices, improving the layout responsiveness.