### PR TITLE
refactor(menu): added italic value

### DIFF
--- a/lib/MBMigration/Builder/Layout/Theme/Anthem/Assets/dist/index.js
+++ b/lib/MBMigration/Builder/Layout/Theme/Anthem/Assets/dist/index.js
@@ -131,8 +131,8 @@
       "use strict";
       Object.defineProperty(exports, "__esModule", { value: true });
       exports.orElse = exports.isT = exports.isNothing = void 0;
-      var isNothing = function(v2) {
-        return v2 === null || v2 === void 0;
+      var isNothing = function(v) {
+        return v === null || v === void 0;
       };
       exports.isNothing = isNothing;
       var isT = function(t) {
@@ -144,8 +144,8 @@
         for (var _i = 0; _i < arguments.length; _i++) {
           args[_i] = arguments[_i];
         }
-        return args.length === 1 ? function(v2) {
-          return (0, exports.isNothing)(v2) ? args[0] : v2;
+        return args.length === 1 ? function(v) {
+          return (0, exports.isNothing)(v) ? args[0] : v;
         } : (0, exports.isNothing)(args[1]) ? args[0] : args[1];
       }
       exports.orElse = orElse;
@@ -171,8 +171,8 @@
           for (var _i2 = 0; _i2 < arguments.length; _i2++) {
             args[_i2] = arguments[_i2];
           }
-          return args.every(Nothing_1.isT) ? (_a2 = fns.reduce(function(v2, fn) {
-            return (0, Nothing_1.isT)(v2) ? fn(v2) : void 0;
+          return args.every(Nothing_1.isT) ? (_a2 = fns.reduce(function(v, fn) {
+            return (0, Nothing_1.isT)(v) ? fn(v) : void 0;
           }, h.apply(void 0, args))) !== null && _a2 !== void 0 ? _a2 : void 0 : void 0;
         };
       }
@@ -202,17 +202,17 @@
       Object.defineProperty(exports, "__esModule", { value: true });
       exports._parse = exports.call = exports.isOptional = void 0;
       var Nothing_1 = require_Nothing();
-      var isOptional = function(v2) {
-        return v2.__type === "optional";
+      var isOptional = function(v) {
+        return v.__type === "optional";
       };
       exports.isOptional = isOptional;
-      var call = function(p, v2) {
+      var call = function(p, v) {
         switch (p.__type) {
           case "optional":
           case "strict":
-            return p.fn(v2);
+            return p.fn(v);
           default:
-            return p(v2);
+            return p(v);
         }
       };
       exports.call = call;
@@ -222,11 +222,11 @@
           if (!Object.prototype.hasOwnProperty.call(parsers, p)) {
             continue;
           }
-          var v2 = (0, exports.call)(parsers[p], object);
-          if (!(0, exports.isOptional)(parsers[p]) && (0, Nothing_1.isNothing)(v2)) {
+          var v = (0, exports.call)(parsers[p], object);
+          if (!(0, exports.isOptional)(parsers[p]) && (0, Nothing_1.isNothing)(v)) {
             return void 0;
           }
-          b[p] = v2;
+          b[p] = v;
         }
         return b;
       }
@@ -303,9 +303,9 @@
             args[_i2] = arguments[_i2];
           }
           for (var i = 0; i <= fns.length; i++) {
-            var v2 = (_a = fns[i]) === null || _a === void 0 ? void 0 : _a.call.apply(_a, __spreadArray([fns], args, false));
-            if (!(0, Nothing_1.isNothing)(v2)) {
-              return v2;
+            var v = (_a = fns[i]) === null || _a === void 0 ? void 0 : _a.call.apply(_a, __spreadArray([fns], args, false));
+            if (!(0, Nothing_1.isNothing)(v)) {
+              return v;
             }
           }
         };
@@ -369,12 +369,12 @@
   var init_string = __esm({
     "../../../../../../../packages/utils/src/reader/string.ts"() {
       "use strict";
-      read = (v2) => {
-        switch (typeof v2) {
+      read = (v) => {
+        switch (typeof v) {
           case "string":
-            return v2;
+            return v;
           case "number":
-            return isNaN(v2) ? void 0 : v2.toString();
+            return isNaN(v) ? void 0 : v.toString();
           default:
             return void 0;
         }
@@ -510,7 +510,7 @@
       hexRegex = /^#(?:[A-Fa-f0-9]{3}){1,2}$/;
       rgbRegex = /^rgb\s*[(]\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)\s*[)]$/;
       rgbaRegex = /^rgba\s*[(]\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)\s*,\s*(0*(?:\.\d+)?|1(?:\.0*)?)\s*[)]$/;
-      isHex = (v2) => hexRegex.test(v2);
+      isHex = (v) => hexRegex.test(v);
       fromRgb = (rgb) => {
         return "#" + ("0" + rgb[0].toString(16)).slice(-2) + ("0" + rgb[1].toString(16)).slice(-2) + ("0" + rgb[2].toString(16)).slice(-2);
       };
@@ -571,7 +571,7 @@
   });
 
   // ../../../../../../../packages/elements/src/utils/getModel.ts
-  var v, getModel;
+  var getModel;
   var init_getModel = __esm({
     "../../../../../../../packages/elements/src/utils/getModel.ts"() {
       "use strict";
@@ -580,26 +580,11 @@
       init_getNodeStyle();
       init_capByPrefix();
       init_toCamelCase();
-      v = {
-        "font-family": void 0,
-        "font-family-type": "uploaded",
-        "font-weight": void 0,
-        "font-size": void 0,
-        "line-height": void 0,
-        "letter-spacing": void 0,
-        "font-style": "",
-        uppercase: false,
-        borderColorHex: void 0,
-        borderColorOpacity: 1,
-        borderWidth: 1,
-        colorHex: void 0,
-        colorOpacity: 1
-      };
       getModel = (data) => {
-        const { node, families, defaultFamily } = data;
+        const { node, families, defaultFamily, modelDefaults: modelDefaults2 } = data;
         const styles = getNodeStyle(node);
         const dic = {};
-        Object.keys(v).forEach((key) => {
+        Object.keys(modelDefaults2).forEach((key) => {
           switch (key) {
             case "font-family": {
               const value = `${styles[key]}`;
@@ -639,35 +624,46 @@
               }
               break;
             }
-            case "colorHex": {
+            case "color-hex": {
               const toHex = parseColorString(`${styles["color"]}`);
               dic[toCamelCase(key)] = toHex?.hex ?? "#000000";
               break;
             }
-            case "colorOpacity": {
+            case "bg-color-hex": {
+              const toHex = parseColorString(`${styles["background-color"]}`);
+              dic[toCamelCase(key)] = toHex?.hex ?? "#ffffff";
+              break;
+            }
+            case "color-opacity": {
               const toHex = parseColorString(`${styles["color"]}`);
+              const opacity = isNaN(+styles.opacity) ? 1 : styles.opacity;
+              dic[toCamelCase(key)] = +(toHex?.opacity ?? opacity);
+              break;
+            }
+            case "bg-color-opacity": {
+              const toHex = parseColorString(`${styles["background-color"]}`);
               const opacity = isNaN(+styles.opacity) ? 1 : styles.opacity;
               dic[toCamelCase(key)] = +(toHex?.opacity ?? opacity);
               break;
             }
             case "uppercase": {
               const value = `${styles["text-transform"]}`;
-              const isUppercase = value === "uppercase" ? "true" : "false";
+              const isUppercase = value === "uppercase";
               dic[toCamelCase(key)] = isUppercase;
               break;
             }
-            case "borderColorHex": {
+            case "border-color-hex": {
               const toHex = parseColorString(`${styles["border-bottom-color"]}`);
               dic[toCamelCase(key)] = toHex?.hex ?? "#000000";
               break;
             }
-            case "borderColorOpacity": {
+            case "border-color-opacity": {
               const toHex = parseColorString(`${styles["border-bottom-color"]}`);
               const opacity = isNaN(+styles.opacity) ? 1 : styles.opacity;
               dic[toCamelCase(key)] = +(toHex?.opacity ?? opacity);
               break;
             }
-            case "borderWidth": {
+            case "border-width": {
               const borderWidth = `${styles["border-bottom-width"]}`.replace(
                 /px/g,
                 ""
@@ -681,6 +677,31 @@
           }
         });
         return dic;
+      };
+    }
+  });
+
+  // ../../../../../../../packages/elements/src/Accordion/models.ts
+  var model;
+  var init_models = __esm({
+    "../../../../../../../packages/elements/src/Accordion/models.ts"() {
+      "use strict";
+      model = {
+        "font-family": void 0,
+        "font-family-type": "uploaded",
+        "font-weight": void 0,
+        "font-size": void 0,
+        "line-height": void 0,
+        "letter-spacing": void 0,
+        "font-style": "",
+        "border-color-hex": void 0,
+        "border-color-opacity": 1,
+        "border-width": 1,
+        "color-hex": void 0,
+        "color-opacity": 1,
+        "bg-color-hex": void 0,
+        "bg-color-opacity": 1,
+        uppercase: false
       };
     }
   });
@@ -701,23 +722,23 @@
   var init_number = __esm({
     "../../../../../../../packages/utils/src/reader/number.ts"() {
       "use strict";
-      read2 = (v2) => {
-        switch (typeof v2) {
+      read2 = (v) => {
+        switch (typeof v) {
           case "string": {
-            const v_ = v2 !== "" ? Number(v2) : NaN;
+            const v_ = v !== "" ? Number(v) : NaN;
             return isNaN(v_) ? void 0 : v_;
           }
           case "number":
-            return isNaN(v2) ? void 0 : v2;
+            return isNaN(v) ? void 0 : v;
           default:
             return void 0;
         }
       };
-      readInt = (v2) => {
-        if (typeof v2 === "string") {
-          return parseInt(v2);
+      readInt = (v) => {
+        if (typeof v === "string") {
+          return parseInt(v);
         }
-        return read2(v2);
+        return read2(v);
       };
     }
   });
@@ -729,37 +750,39 @@
       "use strict";
       init_getDataByEntry();
       init_getModel();
+      init_models();
       init_getData();
       init_number();
       warns = {};
       getAccordionV = (data) => {
         const { list, selector } = data;
         const li = list.children[0];
-        let v2 = {};
+        let v = {};
         if (!li) {
           warns["accordion li"] = {
             message: `Accordion don't have ul > li in ${selector}`
           };
-          return v2;
+          return v;
         }
         const title = li.querySelector(".accordion-title");
         if (!title) {
           warns["menu li title"] = {
             message: `Accordion don't have ul > li > .accordion-title in ${selector}`
           };
-          return v2;
+          return v;
         }
         const computedStyles = window.getComputedStyle(title, "::after");
         const fontSize = computedStyles.getPropertyValue("font-size");
         const content = computedStyles.getPropertyValue("content");
         const hasIcon = fontSize && content;
-        v2 = getModel({
+        v = getModel({
           node: title,
+          modelDefaults: model,
           families: data.families,
           defaultFamily: data.defaultFamily
         });
         return {
-          ...v2,
+          ...v,
           ...hasIcon && {
             navIcon: "thin",
             navIconSize: "custom",
@@ -1069,6 +1092,12 @@
               Object.assign(dic, dicKeyForDevices(key, value));
               break;
             }
+            case "italic": {
+              const value = `${styles["font-style"]}`;
+              const isItalic = value === "italic";
+              dic[toCamelCase(key)] = isItalic;
+              break;
+            }
             default: {
               dic[toCamelCase(key)] = styles[key];
             }
@@ -1110,8 +1139,8 @@
     "../../../../../../../packages/utils/src/models/prefixed.ts"() {
       "use strict";
       init_capitalize();
-      prefixed = (v2, prefix) => {
-        return Object.entries(v2).reduce((acc, [key, value]) => {
+      prefixed = (v, prefix) => {
+        return Object.entries(v).reduce((acc, [key, value]) => {
           let _key = prefix + capitalize(key);
           const prefixes = ["active", "mobile", "tablet"];
           const matchedPrefix = prefixes.find((prefix2) => key.startsWith(prefix2));
@@ -1147,7 +1176,7 @@
           families,
           defaultFamily
         } = entry;
-        const model = {
+        const model3 = {
           "font-family": void 0,
           "font-family-type": "uploaded",
           "font-weight": void 0,
@@ -1156,15 +1185,16 @@
           "letter-spacing": void 0,
           "font-style": "",
           "color-hex": void 0,
-          "color-opacity": 1
+          "color-opacity": 1,
+          italic: false
         };
-        const v2 = getModel2({
+        const v = getModel2({
           node: item,
-          modelDefaults: model,
+          modelDefaults: model3,
           families,
           defaultFamily
         });
-        const mMenu = prefixed(v2, "mMenu");
+        const mMenu = prefixed(v, "mMenu");
         Object.assign(
           mMenu,
           dicKeyForDevices("m-menu-color-hex", mMenu["mMenuColorHex"])
@@ -1173,13 +1203,13 @@
           mMenu,
           dicKeyForDevices("m-menu-color-opacity", mMenu["mMenuColorOpacity"])
         );
-        const bgModel = {
+        const bgModel2 = {
           "menu-bg-color-hex": void 0,
           "menu-bg-color-opacity": 1
         };
         const bgV = getModel2({
           node: itemBg,
-          modelDefaults: bgModel,
+          modelDefaults: bgModel2,
           families,
           defaultFamily
         });
@@ -1223,34 +1253,34 @@
             })
           );
         }
-        return { ...v2, ...mMenu, ...bgV, ...paddingV, ...mobileMenuV };
+        return { ...v, ...mMenu, ...bgV, ...paddingV, ...mobileMenuV };
       };
       getHoverV = (entry) => {
         const { item, itemBg, families, defaultFamily } = entry;
-        const model = {
+        const model3 = {
           "hover-color-hex": void 0,
           "hover-color-opacity": 1,
           "active-color-hex": void 0,
           "active-color-opacity": 1
         };
-        const v2 = getModel2({
+        const v = getModel2({
           node: item,
-          modelDefaults: model,
+          modelDefaults: model3,
           families,
           defaultFamily
         });
-        const mMenu = prefixed(v2, "mMenu");
-        const bgModel = {
+        const mMenu = prefixed(v, "mMenu");
+        const bgModel2 = {
           "hover-menu-bg-color-hex": void 0,
           "hover-menu-bg-color-opacity": void 0
         };
         const bgV = getModel2({
           node: itemBg,
-          modelDefaults: bgModel,
+          modelDefaults: bgModel2,
           families,
           defaultFamily
         });
-        return { ...v2, ...bgV, ...mMenu };
+        return { ...v, ...bgV, ...mMenu };
       };
       getMenuItem = (entry) => {
         const {
@@ -1345,7 +1375,7 @@
       init_prefixed();
       getV2 = (entry) => {
         const { item, itemBg, families, defaultFamily } = entry;
-        const model = {
+        const model3 = {
           "font-family": void 0,
           "font-family-type": "uploaded",
           "font-weight": void 0,
@@ -1354,51 +1384,52 @@
           "letter-spacing": void 0,
           "font-style": "",
           "color-hex": void 0,
-          "color-opacity": void 0
+          "color-opacity": void 0,
+          italic: false
         };
-        const v2 = getModel2({
+        const v = getModel2({
           node: item,
-          modelDefaults: model,
+          modelDefaults: model3,
           families,
           defaultFamily
         });
-        const bgModel = {
+        const bgModel2 = {
           "bg-color-hex": void 0,
           "bg-color-opacity": void 0
         };
         const bgV = getModel2({
           node: itemBg,
-          modelDefaults: bgModel,
+          modelDefaults: bgModel2,
           families,
           defaultFamily
         });
-        return { ...prefixed(v2, "subMenu"), ...prefixed(bgV, "subMenu") };
+        return { ...prefixed(v, "subMenu"), ...prefixed(bgV, "subMenu") };
       };
       getHoverV2 = (entry) => {
         const { item, itemBg, families, defaultFamily } = entry;
-        const model = {
+        const model3 = {
           "color-hex": void 0,
           "color-opacity": void 0
         };
-        const v2 = getModel2({
+        const v = getModel2({
           node: item,
-          modelDefaults: model,
+          modelDefaults: model3,
           families,
           defaultFamily
         });
-        const bgModel = {
+        const bgModel2 = {
           "bg-color-hex": void 0,
           "bg-color-opacity": 1
         };
         const bgV = getModel2({
           node: itemBg,
-          modelDefaults: bgModel,
+          modelDefaults: bgModel2,
           families,
           defaultFamily
         });
         return {
-          ...prefixed(v2, "hoverSubMenu"),
-          ...prefixed(v2, "activeSubMenu"),
+          ...prefixed(v, "hoverSubMenu"),
+          ...prefixed(v, "activeSubMenu"),
           ...prefixed(bgV, "hoverSubMenu")
         };
       };
@@ -1488,35 +1519,65 @@
     }
   });
 
+  // ../../../../../../../packages/elements/src/Tabs/models.ts
+  var model2, bgModel;
+  var init_models2 = __esm({
+    "../../../../../../../packages/elements/src/Tabs/models.ts"() {
+      "use strict";
+      model2 = {
+        "font-family": void 0,
+        "font-family-type": "uploaded",
+        "font-weight": void 0,
+        "font-size": void 0,
+        "line-height": void 0,
+        "letter-spacing": void 0,
+        "font-style": "",
+        "border-color-hex": void 0,
+        "border-color-opacity": 1,
+        "border-width": 1,
+        "color-hex": void 0,
+        "color-opacity": 1,
+        uppercase: false
+      };
+      bgModel = {
+        "bg-color-hex": void 0,
+        "bg-color-opacity": 1
+      };
+    }
+  });
+
   // ../../../../../../../packages/elements/src/Tabs/index.ts
   var warns2, getTabsV, getTabs;
   var init_Tabs = __esm({
     "../../../../../../../packages/elements/src/Tabs/index.ts"() {
       "use strict";
       init_getModel();
+      init_models2();
       init_getData();
-      init_parseColorString();
       warns2 = {};
       getTabsV = (data) => {
         const { node, list, selector } = data;
         const tab = list.children[0];
-        let v2 = {};
         if (!tab) {
           warns2["tabs tab"] = {
             message: `Tabs don't have .tabs-list > .tab-title in ${selector}`
           };
-          return v2;
         }
-        v2 = getModel({
+        const v = getModel({
           node: tab,
+          modelDefaults: model2,
           families: data.families,
           defaultFamily: data.defaultFamily
         });
-        const { backgroundColor, opacity } = window.getComputedStyle(node);
-        const color = parseColorString(backgroundColor);
+        const bgV = getModel({
+          node,
+          modelDefaults: bgModel,
+          families: data.families,
+          defaultFamily: data.defaultFamily
+        });
         return {
-          ...v2,
-          ...color && { bgColorHex: color.hex, opacity: color.opacity ?? +opacity },
+          ...v,
+          ...bgV,
           navStyle: "style-3"
         };
       };
@@ -3374,7 +3435,7 @@
 
   // ../../../../../../../packages/utils/src/fp/pipe.ts
   function pipe(...[h, ...fns]) {
-    return (...args) => fns.reduce((v2, fn) => fn(v2), h(...args));
+    return (...args) => fns.reduce((v, fn) => fn(v), h(...args));
   }
   var init_pipe = __esm({
     "../../../../../../../packages/utils/src/fp/pipe.ts"() {
@@ -3387,13 +3448,13 @@
   var init_isNullish = __esm({
     "../../../../../../../packages/utils/src/isNullish.ts"() {
       "use strict";
-      isNullish = (v2) => v2 === void 0 || v2 === null || typeof v2 === "number" && Number.isNaN(v2);
+      isNullish = (v) => v === void 0 || v === null || typeof v === "number" && Number.isNaN(v);
     }
   });
 
   // ../../../../../../../packages/utils/src/onNullish.ts
   function onNullish(...args) {
-    return args.length === 1 ? (v2) => isNullish(v2) ? args[0] : v2 : isNullish(args[1]) ? args[0] : args[1];
+    return args.length === 1 ? (v) => isNullish(v) ? args[0] : v : isNullish(args[1]) ? args[0] : args[1];
   }
   var init_onNullish = __esm({
     "../../../../../../../packages/utils/src/onNullish.ts"() {
@@ -3525,8 +3586,8 @@
         const textTransform = getTransform(getNodeStyle(node));
         const icon = node.querySelector(iconSelector);
         if (icon) {
-          const model = getModel3(icon, urlMap);
-          const name = read(model.value.name);
+          const model3 = getModel3(icon, urlMap);
+          const name = read(model3.value.name);
           icon.remove();
           if (name) {
             iconModel = {
@@ -3600,18 +3661,18 @@
     buttons.forEach((button) => {
       const parentElement = findNearestBlockParent(button);
       const style = getNodeStyle(button);
-      const model = getModel4({ node: button, defaultFamily, families, urlMap });
+      const model3 = getModel4({ node: button, defaultFamily, families, urlMap });
       const group = groups.get(parentElement) ?? { value: { items: [] } };
       const wrapperModel = createCloneableModel({
         _styles: ["wrapper-clone", "wrapper-clone--button"],
-        items: [...group.value.items, model],
+        items: [...group.value.items, model3],
         horizontalAlign: textAlign[style["text-align"]]
       });
       groups.set(parentElement, wrapperModel);
     });
     const models = [];
-    groups.forEach((model) => {
-      models.push(model);
+    groups.forEach((model3) => {
+      models.push(model3);
     });
     return models;
   }
@@ -3652,18 +3713,18 @@
       const isIconText = parentNode?.nodeName === "#text";
       const iconNode = isIconText ? node : parentNode;
       const style = iconNode ? getNodeStyle(iconNode) : {};
-      const model = getModel3(icon, urlMap);
+      const model3 = getModel3(icon, urlMap);
       const group = groups.get(parentElement) ?? { value: { items: [] } };
       const wrapperModel = createCloneableModel({
         _styles: ["wrapper-clone", "wrapper-clone--icon"],
-        items: [...group.value.items, model],
+        items: [...group.value.items, model3],
         horizontalAlign: textAlign[style["text-align"]]
       });
       groups.set(parentElement, wrapperModel);
     });
     const models = [];
-    groups.forEach((model) => {
-      models.push(model);
+    groups.forEach((model3) => {
+      models.push(model3);
     });
     return models;
   }
@@ -4410,7 +4471,9 @@
               stack.set(_node, { type: "text" });
             }
           } else {
-            stack.append(_node, { type: "text" });
+            if (_node.textContent?.trim()) {
+              stack.append(_node, { type: "text" });
+            }
           }
         });
         const allElements = stack.getAll();
@@ -4460,8 +4523,8 @@
           if (node2 instanceof HTMLElement) {
             switch (node2.dataset.type) {
               case "text": {
-                const model = getTextModel({ ...entry, node: node2 });
-                data.push(model);
+                const model3 = getTextModel({ ...entry, node: node2 });
+                data.push(model3);
                 break;
               }
               case "button": {

--- a/packages/elements/src/Menu/getMenuItem.ts
+++ b/packages/elements/src/Menu/getMenuItem.ts
@@ -39,7 +39,8 @@ const getV = (entry: MenuItemData) => {
     "letter-spacing": undefined,
     "font-style": "",
     "color-hex": undefined,
-    "color-opacity": 1
+    "color-opacity": 1,
+    italic: false
   };
 
   const v = getModel({

--- a/packages/elements/src/Menu/getSubMenuItem.ts
+++ b/packages/elements/src/Menu/getSubMenuItem.ts
@@ -26,7 +26,8 @@ const getV = (entry: MenuItemData) => {
     "letter-spacing": undefined,
     "font-style": "",
     "color-hex": undefined,
-    "color-opacity": undefined
+    "color-opacity": undefined,
+    italic: false
   };
 
   const v = getModel({

--- a/packages/elements/src/Menu/utils/getModel.ts
+++ b/packages/elements/src/Menu/utils/getModel.ts
@@ -1,4 +1,5 @@
 import { MenuItemElement } from "../../types/type";
+import { Literal, MValue } from "utils";
 import { parseColorString } from "utils/src/color/parseColorString";
 import { dicKeyForDevices } from "utils/src/dicKeyForDevices";
 import { getNodeStyle } from "utils/src/dom/getNodeStyle";
@@ -6,7 +7,7 @@ import { toCamelCase } from "utils/src/text/toCamelCase";
 
 interface Model {
   node: MenuItemElement;
-  modelDefaults: Record<string, string | number | undefined>;
+  modelDefaults: Record<string, MValue<Literal | boolean>>;
   families: Record<string, string>;
   defaultFamily: string;
 }
@@ -20,7 +21,7 @@ const pxToEm = (lineHeightValue: string, fontSize: string | number): number => {
 export const getModel = (data: Model) => {
   const { node, modelDefaults, families, defaultFamily } = data;
   const styles = getNodeStyle(node.item, node.pseudoEl);
-  const dic: Record<string, string | number> = {};
+  const dic: Record<string, Literal | boolean> = {};
 
   Object.keys(modelDefaults).forEach((key) => {
     switch (key) {
@@ -135,6 +136,13 @@ export const getModel = (data: Model) => {
         const value = +(toHex?.opacity ?? opacity);
 
         Object.assign(dic, dicKeyForDevices(key, value));
+        break;
+      }
+      case "italic": {
+        const value = `${styles["font-style"]}`;
+        const isItalic = value === "italic";
+
+        dic[toCamelCase(key)] = isItalic;
         break;
       }
       default: {

--- a/packages/elements/src/Tabs/__tests__/getTabs.ts
+++ b/packages/elements/src/Tabs/__tests__/getTabs.ts
@@ -41,7 +41,7 @@ const ex1: Data = {
       mobileLineHeight: 1.2,
       tabletLineHeight: 1.2,
       navStyle: "style-3",
-      uppercase: "false"
+      uppercase: false
     }
   }
 };

--- a/packages/elements/src/Text/utils/dom/getContainerStackWithNodes.ts
+++ b/packages/elements/src/Text/utils/dom/getContainerStackWithNodes.ts
@@ -272,7 +272,9 @@ export const getContainerStackWithNodes = (parentNode: Element): Container => {
         stack.set(_node, { type: "text" });
       }
     } else {
-      stack.append(_node, { type: "text" });
+      if (_node.textContent?.trim()) {
+        stack.append(_node, { type: "text" });
+      }
     }
   });
 

--- a/packages/elements/src/utils/getModel.ts
+++ b/packages/elements/src/utils/getModel.ts
@@ -19,7 +19,7 @@ interface Model {
 export const getModel = (data: Model) => {
   const { node, families, defaultFamily, modelDefaults } = data;
   const styles = getNodeStyle(node);
-  const dic: Record<string, string | number> = {};
+  const dic: Record<string, Literal | boolean> = {};
 
   Object.keys(modelDefaults).forEach((key) => {
     switch (key) {
@@ -95,7 +95,7 @@ export const getModel = (data: Model) => {
       }
       case "uppercase": {
         const value = `${styles["text-transform"]}`;
-        const isUppercase = value === "uppercase" ? "true" : "false";
+        const isUppercase = value === "uppercase";
 
         dic[toCamelCase(key)] = isUppercase;
         break;

--- a/packages/utils/src/dicKeyForDevices.ts
+++ b/packages/utils/src/dicKeyForDevices.ts
@@ -1,10 +1,11 @@
 import { capByPrefix } from "utils/src/text/capByPrefix";
 import { toCamelCase } from "utils/src/text/toCamelCase";
+import { Literal } from "utils/src/types";
 
 /**
  * Adds desktop,mobile and tablet keys to dictionary
  */
-export const dicKeyForDevices = (key: string, value: string | number) => {
+export const dicKeyForDevices = (key: string, value: Literal | boolean) => {
   return {
     [toCamelCase(key)]: value,
     [toCamelCase(capByPrefix("mobile", key))]: value,


### PR DESCRIPTION
| Q  | A |
| ------------- | ------------- |
| Screenshot  | N/A |
| Related tickets	  | https://github.com/bagrinsergiu/MB-Support/issues/479 |

### Additional

![2024-10-25_15-39](https://github.com/user-attachments/assets/5a947d4c-f453-4cf1-8711-e3147895dfbb)

![2024-10-25_15-31](https://github.com/user-attachments/assets/f6ec4358-8203-45ca-982e-d6d1aa2fac80)


> * Fixed: RichText Icon spacing

https://github.com/bagrinsergiu/MB-migration/pull/404/files#diff-5824251c727af26032702e76456fed4ad1865b1b97b9aca11b37f98bf733e2ddR275-R277

by removing an empty space which had an overall height of 40 px

### Changelog

* Fixed: RichText Icon spacing
* Improved : Added Italic value to menu

