### PR TITLE
Add wrapper line with border color to Sermons MediaLayoutElement

### DIFF
--- a/lib/MBMigration/Builder/Layout/Theme/Anthem/Elements/Sermons/MediaLayoutElement.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Anthem/Elements/Sermons/MediaLayoutElement.php
@@ -1,8 +1,49 @@
 <?php
 namespace MBMigration\Builder\Layout\Theme\Anthem\Elements\Sermons;
 
+use MBMigration\Builder\BrizyComponent\BrizyComponent;
+use MBMigration\Builder\Layout\Common\ElementContextInterface;
+use MBMigration\Builder\Utils\ColorConverter;
+
 class MediaLayoutElement extends \MBMigration\Builder\Layout\Common\Elements\Sermons\MediaLayoutElement
 {
+    protected function internalTransformToItem(ElementContextInterface $data): BrizyComponent
+    {
+        $brizySection = parent::internalTransformToItem($data);
+        $mbSectionItem = $data->getMbSection();
+        $itemsKit = $data->getThemeContext()->getBrizyKit();
+
+        $wrapperLine = new BrizyComponent(json_decode($itemsKit['global']['wrapper--line'], true));
+
+        $mbSectionItem['items'] = $this->sortItems($mbSectionItem['items']);
+        $titleMb = $this->getItemByType($mbSectionItem, 'title');
+
+        $menuSectionSelector = '[data-id="' . $titleMb['id'] . '"]';
+        $wrapperLineStyles = $this->browserPage->evaluateScript(
+            'brizy.getStyles',
+            [
+                'selector' => $menuSectionSelector,
+                'styleProperties' => ['border-bottom-color',],
+                'families' => [],
+                'defaultFamily' => '',
+            ]
+        );
+
+        $headStyle = [
+            'line-color' => ColorConverter::convertColorRgbToHex($wrapperLineStyles['data']['border-bottom-color']),
+        ];
+
+        $wrapperLine->getItemWithDepth(0)
+            ->getValue()
+            ->set_borderColorHex($headStyle['line-color']);
+
+        $brizySection->getItemWithDepth(0)
+            ->getValue()
+            ->add_items([$wrapperLine], 1);
+
+        return $brizySection;
+    }
+
     protected function getPropertiesMainSection(): array
     {
         return [


### PR DESCRIPTION
Introduced a new method `internalTransformToItem` that incorporates a wrapper line component with a dynamic border color. The color is extracted using Brizy's script evaluation, converted to hex, and then applied to the wrapper line before being added to the Brizy section.