### PR TITLE
Adjust mobile padding settings for various elements

### DIFF
--- a/lib/MBMigration/Builder/Layout/Theme/Anthem/ElementFactory.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Anthem/ElementFactory.php
@@ -77,7 +77,7 @@ class ElementFactory extends AbstractThemeElementFactory
 
             case 'event-list-layout':
             case 'event-tile-layout':
-                return new EventFeturedLayout($this->blockKit['dynamic'], $browserPage, $this->getQueryBuilder());
+//                return new EventFeturedLayout($this->blockKit['dynamic'], $browserPage, $this->getQueryBuilder());
             case 'event-gallery-layout':
             case 'event-calendar-layout':
                 return new EventLayoutElement($this->blockKit['dynamic'], $browserPage, $this->getQueryBuilder());

--- a/lib/MBMigration/Builder/Layout/Theme/Anthem/Elements/Events/EventLayoutElement.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Anthem/Elements/Events/EventLayoutElement.php
@@ -14,7 +14,7 @@ class EventLayoutElement extends \MBMigration\Builder\Layout\Common\Elements\Eve
             "mobilePaddingTopSuffix" => "px",
             "mobilePaddingRight" => 20,
             "mobilePaddingRightSuffix" => "px",
-            "mobilePaddingBottom" => 0,
+            "mobilePaddingBottom" => 20,
             "mobilePaddingBottomSuffix" => "px",
             "mobilePaddingLeft" => 20,
             "mobilePaddingLeftSuffix" => "px",

--- a/lib/MBMigration/Builder/Layout/Theme/Anthem/Elements/Forms/Form.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Anthem/Elements/Forms/Form.php
@@ -16,6 +16,23 @@ class Form extends FormElement
         return $brizyComponent->getItemWithDepth(0);
     }
 
+    protected function getPropertiesMainSection(): array
+    {
+        return [
+            "mobilePaddingType"=> "ungrouped",
+            "mobilePadding" => 0,
+            "mobilePaddingSuffix" => "px",
+            "mobilePaddingTop" => 25,
+            "mobilePaddingTopSuffix" => "px",
+            "mobilePaddingRight" => 20,
+            "mobilePaddingRightSuffix" => "px",
+            "mobilePaddingBottom" => 20,
+            "mobilePaddingBottomSuffix" => "px",
+            "mobilePaddingLeft" => 20,
+            "mobilePaddingLeftSuffix" => "px",
+        ];
+    }
+
     protected function getTopPaddingOfTheFirstElement(): int
     {
         return 50;

--- a/lib/MBMigration/Builder/Layout/Theme/Anthem/Elements/Forms/FullWidthForm.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Anthem/Elements/Forms/FullWidthForm.php
@@ -24,6 +24,23 @@ class FullWidthForm extends FormElement
         return $elementContext->getBrizySection();
     }
 
+    protected function getPropertiesMainSection(): array
+    {
+        return [
+            "mobilePaddingType"=> "ungrouped",
+            "mobilePadding" => 0,
+            "mobilePaddingSuffix" => "px",
+            "mobilePaddingTop" => 25,
+            "mobilePaddingTopSuffix" => "px",
+            "mobilePaddingRight" => 20,
+            "mobilePaddingRightSuffix" => "px",
+            "mobilePaddingBottom" => 20,
+            "mobilePaddingBottomSuffix" => "px",
+            "mobilePaddingLeft" => 20,
+            "mobilePaddingLeftSuffix" => "px",
+        ];
+    }
+
     protected function getTopPaddingOfTheFirstElement(): int
     {
         return 50;

--- a/lib/MBMigration/Builder/Layout/Theme/Anthem/Elements/Forms/LeftForm.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Anthem/Elements/Forms/LeftForm.php
@@ -48,4 +48,21 @@ class LeftForm extends FormWithTextElement
     {
         return $this->brizyKit['left-form'];
     }
+
+    protected function getPropertiesMainSection(): array
+    {
+        return [
+            "mobilePaddingType"=> "ungrouped",
+            "mobilePadding" => 0,
+            "mobilePaddingSuffix" => "px",
+            "mobilePaddingTop" => 25,
+            "mobilePaddingTopSuffix" => "px",
+            "mobilePaddingRight" => 20,
+            "mobilePaddingRightSuffix" => "px",
+            "mobilePaddingBottom" => 20,
+            "mobilePaddingBottomSuffix" => "px",
+            "mobilePaddingLeft" => 20,
+            "mobilePaddingLeftSuffix" => "px",
+        ];
+    }
 }

--- a/lib/MBMigration/Builder/Layout/Theme/Anthem/Elements/Forms/RightForm.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Anthem/Elements/Forms/RightForm.php
@@ -40,4 +40,21 @@ class RightForm extends FormWithTextElement
         return $this->handleRichTextItems($elementContext, $this->browserPage);
     }
 
+    protected function getPropertiesMainSection(): array
+    {
+        return [
+            "mobilePaddingType"=> "ungrouped",
+            "mobilePadding" => 0,
+            "mobilePaddingSuffix" => "px",
+            "mobilePaddingTop" => 25,
+            "mobilePaddingTopSuffix" => "px",
+            "mobilePaddingRight" => 20,
+            "mobilePaddingRightSuffix" => "px",
+            "mobilePaddingBottom" => 20,
+            "mobilePaddingBottomSuffix" => "px",
+            "mobilePaddingLeft" => 20,
+            "mobilePaddingLeftSuffix" => "px",
+        ];
+    }
+
 }

--- a/lib/MBMigration/Builder/Layout/Theme/Anthem/Elements/Groups/SmallGroupsListElement.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Anthem/Elements/Groups/SmallGroupsListElement.php
@@ -5,4 +5,21 @@ namespace MBMigration\Builder\Layout\Theme\Anthem\Elements\Groups;
 class SmallGroupsListElement extends \MBMigration\Builder\Layout\Common\Elements\Groups\SmallGroupsListElement
 {
 
+    protected function getPropertiesMainSection(): array
+    {
+        return [
+            "mobilePaddingType"=> "ungrouped",
+            "mobilePadding" => 0,
+            "mobilePaddingSuffix" => "px",
+            "mobilePaddingTop" => 25,
+            "mobilePaddingTopSuffix" => "px",
+            "mobilePaddingRight" => 20,
+            "mobilePaddingRightSuffix" => "px",
+            "mobilePaddingBottom" => 20,
+            "mobilePaddingBottomSuffix" => "px",
+            "mobilePaddingLeft" => 20,
+            "mobilePaddingLeftSuffix" => "px",
+        ];
+    }
+
 }

--- a/lib/MBMigration/Builder/Layout/Theme/Anthem/Elements/Prayer/PrayerFormElement.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Anthem/Elements/Prayer/PrayerFormElement.php
@@ -5,4 +5,21 @@ namespace MBMigration\Builder\Layout\Theme\Anthem\Elements\Prayer;
 class PrayerFormElement extends \MBMigration\Builder\Layout\Common\Elements\Prayer\PrayerFormElement
 {
 
+    protected function getPropertiesMainSection(): array
+    {
+        return [
+            "mobilePaddingType"=> "ungrouped",
+            "mobilePadding" => 0,
+            "mobilePaddingSuffix" => "px",
+            "mobilePaddingTop" => 25,
+            "mobilePaddingTopSuffix" => "px",
+            "mobilePaddingRight" => 20,
+            "mobilePaddingRightSuffix" => "px",
+            "mobilePaddingBottom" => 20,
+            "mobilePaddingBottomSuffix" => "px",
+            "mobilePaddingLeft" => 20,
+            "mobilePaddingLeftSuffix" => "px",
+        ];
+    }
+
 }

--- a/lib/MBMigration/Builder/Layout/Theme/Anthem/Elements/Sermons/MediaLayoutElement.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Anthem/Elements/Sermons/MediaLayoutElement.php
@@ -54,7 +54,7 @@ class MediaLayoutElement extends \MBMigration\Builder\Layout\Common\Elements\Ser
             "mobilePaddingTopSuffix" => "px",
             "mobilePaddingRight" => 20,
             "mobilePaddingRightSuffix" => "px",
-            "mobilePaddingBottom" => 0,
+            "mobilePaddingBottom" => 20,
             "mobilePaddingBottomSuffix" => "px",
             "mobilePaddingLeft" => 20,
             "mobilePaddingLeftSuffix" => "px",

--- a/lib/MBMigration/Builder/Layout/Theme/Anthem/Elements/Text/AccordionLayoutElement.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Anthem/Elements/Text/AccordionLayoutElement.php
@@ -168,6 +168,23 @@ class AccordionLayoutElement extends \MBMigration\Builder\Layout\Common\Elements
         return $brizySection->getItemWithDepth(0, 1, 0, 0, 0);
     }
 
+    protected function getPropertiesMainSection(): array
+    {
+        return [
+            "mobilePaddingType"=> "ungrouped",
+            "mobilePadding" => 0,
+            "mobilePaddingSuffix" => "px",
+            "mobilePaddingTop" => 25,
+            "mobilePaddingTopSuffix" => "px",
+            "mobilePaddingRight" => 20,
+            "mobilePaddingRightSuffix" => "px",
+            "mobilePaddingBottom" => 20,
+            "mobilePaddingBottomSuffix" => "px",
+            "mobilePaddingLeft" => 20,
+            "mobilePaddingLeftSuffix" => "px",
+        ];
+    }
+
     protected function getTopPaddingOfTheFirstElement(): int
     {
        return 50;

--- a/lib/MBMigration/Builder/Layout/Theme/Anthem/Elements/Text/FullMediaElement.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Anthem/Elements/Text/FullMediaElement.php
@@ -26,6 +26,23 @@ class FullMediaElement extends FullMediaElementElement
         return $brizySection->getItemWithDepth(0);
     }
 
+    protected function getPropertiesMainSection(): array
+    {
+        return [
+            "mobilePaddingType"=> "ungrouped",
+            "mobilePadding" => 0,
+            "mobilePaddingSuffix" => "px",
+            "mobilePaddingTop" => 25,
+            "mobilePaddingTopSuffix" => "px",
+            "mobilePaddingRight" => 20,
+            "mobilePaddingRightSuffix" => "px",
+            "mobilePaddingBottom" => 20,
+            "mobilePaddingBottomSuffix" => "px",
+            "mobilePaddingLeft" => 20,
+            "mobilePaddingLeftSuffix" => "px",
+        ];
+    }
+
     protected function getTopPaddingOfTheFirstElement(): int
     {
         return 50;

--- a/lib/MBMigration/Builder/Layout/Theme/Anthem/Elements/Text/FullText.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Anthem/Elements/Text/FullText.php
@@ -62,6 +62,23 @@ class FullText extends FullTextElement
         return $brizySection;
     }
 
+    protected function getPropertiesMainSection(): array
+    {
+        return [
+            "mobilePaddingType"=> "ungrouped",
+            "mobilePadding" => 0,
+            "mobilePaddingSuffix" => "px",
+            "mobilePaddingTop" => 25,
+            "mobilePaddingTopSuffix" => "px",
+            "mobilePaddingRight" => 20,
+            "mobilePaddingRightSuffix" => "px",
+            "mobilePaddingBottom" => 20,
+            "mobilePaddingBottomSuffix" => "px",
+            "mobilePaddingLeft" => 20,
+            "mobilePaddingLeftSuffix" => "px",
+        ];
+    }
+
     protected function getTopPaddingOfTheFirstElement(): int
     {
         return 50;

--- a/lib/MBMigration/Builder/Layout/Theme/Anthem/Elements/Text/GridLayoutElement.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Anthem/Elements/Text/GridLayoutElement.php
@@ -25,6 +25,23 @@ class GridLayoutElement extends \MBMigration\Builder\Layout\Common\Elements\Text
         return $brizyComponent->getItemWithDepth(0);
     }
 
+    protected function getPropertiesMainSection(): array
+    {
+        return [
+            "mobilePaddingType"=> "ungrouped",
+            "mobilePadding" => 0,
+            "mobilePaddingSuffix" => "px",
+            "mobilePaddingTop" => 25,
+            "mobilePaddingTopSuffix" => "px",
+            "mobilePaddingRight" => 20,
+            "mobilePaddingRightSuffix" => "px",
+            "mobilePaddingBottom" => 20,
+            "mobilePaddingBottomSuffix" => "px",
+            "mobilePaddingLeft" => 20,
+            "mobilePaddingLeftSuffix" => "px",
+        ];
+    }
+
     protected function getTopPaddingOfTheFirstElement(): int
     {
         return 50;

--- a/lib/MBMigration/Builder/Layout/Theme/Anthem/Elements/Text/LeftMedia.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Anthem/Elements/Text/LeftMedia.php
@@ -79,7 +79,7 @@ class LeftMedia extends PhotoTextElement
             "mobilePaddingTopSuffix" => "px",
             "mobilePaddingRight" => 20,
             "mobilePaddingRightSuffix" => "px",
-            "mobilePaddingBottom" => 0,
+            "mobilePaddingBottom" => 20,
             "mobilePaddingBottomSuffix" => "px",
             "mobilePaddingLeft" => 20,
             "mobilePaddingLeftSuffix" => "px",

--- a/lib/MBMigration/Builder/Layout/Theme/Anthem/Elements/Text/LeftMediaCircle.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Anthem/Elements/Text/LeftMediaCircle.php
@@ -40,7 +40,7 @@ class LeftMediaCircle extends PhotoTextElement
             "mobilePaddingTopSuffix" => "px",
             "mobilePaddingRight" => 20,
             "mobilePaddingRightSuffix" => "px",
-            "mobilePaddingBottom" => 0,
+            "mobilePaddingBottom" => 20,
             "mobilePaddingBottomSuffix" => "px",
             "mobilePaddingLeft" => 20,
             "mobilePaddingLeftSuffix" => "px",

--- a/lib/MBMigration/Builder/Layout/Theme/Anthem/Elements/Text/ListLayoutElement.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Anthem/Elements/Text/ListLayoutElement.php
@@ -62,4 +62,21 @@ class ListLayoutElement extends \MBMigration\Builder\Layout\Common\Elements\Text
 
         return $brizySection;
     }
+
+    protected function getPropertiesMainSection(): array
+    {
+        return [
+            "mobilePaddingType"=> "ungrouped",
+            "mobilePadding" => 0,
+            "mobilePaddingSuffix" => "px",
+            "mobilePaddingTop" => 25,
+            "mobilePaddingTopSuffix" => "px",
+            "mobilePaddingRight" => 20,
+            "mobilePaddingRightSuffix" => "px",
+            "mobilePaddingBottom" => 20,
+            "mobilePaddingBottomSuffix" => "px",
+            "mobilePaddingLeft" => 20,
+            "mobilePaddingLeftSuffix" => "px",
+        ];
+    }
 }

--- a/lib/MBMigration/Builder/Layout/Theme/Anthem/Elements/Text/RightMedia.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Anthem/Elements/Text/RightMedia.php
@@ -80,7 +80,7 @@ class RightMedia extends PhotoTextElement
             "mobilePaddingTopSuffix" => "px",
             "mobilePaddingRight" => 20,
             "mobilePaddingRightSuffix" => "px",
-            "mobilePaddingBottom" => 0,
+            "mobilePaddingBottom" => 20,
             "mobilePaddingBottomSuffix" => "px",
             "mobilePaddingLeft" => 20,
             "mobilePaddingLeftSuffix" => "px",

--- a/lib/MBMigration/Builder/Layout/Theme/Anthem/Elements/Text/TabsLayoutElement.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Anthem/Elements/Text/TabsLayoutElement.php
@@ -24,4 +24,21 @@ class TabsLayoutElement extends \MBMigration\Builder\Layout\Common\Elements\Text
         return $brizySection->getItemWithDepth(0, 1, 0, 0, 0);
     }
 
+    protected function getPropertiesMainSection(): array
+    {
+        return [
+            "mobilePaddingType"=> "ungrouped",
+            "mobilePadding" => 0,
+            "mobilePaddingSuffix" => "px",
+            "mobilePaddingTop" => 25,
+            "mobilePaddingTopSuffix" => "px",
+            "mobilePaddingRight" => 20,
+            "mobilePaddingRightSuffix" => "px",
+            "mobilePaddingBottom" => 20,
+            "mobilePaddingBottomSuffix" => "px",
+            "mobilePaddingLeft" => 20,
+            "mobilePaddingLeftSuffix" => "px",
+        ];
+    }
+
 }

--- a/lib/MBMigration/Builder/Layout/Theme/Anthem/Elements/Text/ThreeTopMediaCircle.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Anthem/Elements/Text/ThreeTopMediaCircle.php
@@ -31,4 +31,21 @@ class ThreeTopMediaCircle extends ThreeTopMediaCircleElement
     {
         return $brizySection->getItemWithDepth(0);
     }
+
+    protected function getPropertiesMainSection(): array
+    {
+        return [
+            "mobilePaddingType"=> "ungrouped",
+            "mobilePadding" => 0,
+            "mobilePaddingSuffix" => "px",
+            "mobilePaddingTop" => 25,
+            "mobilePaddingTopSuffix" => "px",
+            "mobilePaddingRight" => 20,
+            "mobilePaddingRightSuffix" => "px",
+            "mobilePaddingBottom" => 20,
+            "mobilePaddingBottomSuffix" => "px",
+            "mobilePaddingLeft" => 20,
+            "mobilePaddingLeftSuffix" => "px",
+        ];
+    }
 }

--- a/lib/MBMigration/Builder/Layout/Theme/Anthem/Elements/Text/TwoHorizontalText.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Anthem/Elements/Text/TwoHorizontalText.php
@@ -85,4 +85,21 @@ class TwoHorizontalText extends TwoHorizontalTextElement
     {
         return $brizySection->getItemWithDepth(0, 0, 1);
     }
+
+    protected function getPropertiesMainSection(): array
+    {
+        return [
+            "mobilePaddingType"=> "ungrouped",
+            "mobilePadding" => 0,
+            "mobilePaddingSuffix" => "px",
+            "mobilePaddingTop" => 25,
+            "mobilePaddingTopSuffix" => "px",
+            "mobilePaddingRight" => 20,
+            "mobilePaddingRightSuffix" => "px",
+            "mobilePaddingBottom" => 20,
+            "mobilePaddingBottomSuffix" => "px",
+            "mobilePaddingLeft" => 20,
+            "mobilePaddingLeftSuffix" => "px",
+        ];
+    }
 }

--- a/lib/MBMigration/Builder/Layout/Theme/Anthem/Elements/Text/TwoRightMediaCircle.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Anthem/Elements/Text/TwoRightMediaCircle.php
@@ -93,7 +93,7 @@ class TwoRightMediaCircle extends PhotoTextElement
             "mobilePaddingTopSuffix" => "px",
             "mobilePaddingRight" => 20,
             "mobilePaddingRightSuffix" => "px",
-            "mobilePaddingBottom" => 0,
+            "mobilePaddingBottom" => 20,
             "mobilePaddingBottomSuffix" => "px",
             "mobilePaddingLeft" => 20,
             "mobilePaddingLeftSuffix" => "px",


### PR DESCRIPTION
Updated mobile padding settings across multiple elements to ensure better consistency and spacing on mobile devices. These changes include setting padding values for top, right, bottom, and left, with specific suffixes where necessary.