### PR TITLE
fix(richtext): appendStylesNode incorrect style node

### DIFF
--- a/lib/MBMigration/Builder/Layout/Theme/Anthem/Assets/dist/index.js
+++ b/lib/MBMigration/Builder/Layout/Theme/Anthem/Assets/dist/index.js
@@ -3930,7 +3930,7 @@
           while (parentElement.firstChild) {
             const firstChild = parentElement.firstChild;
             if (firstChild instanceof HTMLElement) {
-              const computedStyles2 = window.getComputedStyle(parentElement);
+              const computedStyles2 = window.getComputedStyle(firstChild);
               appenStylesToNode(firstChild, computedStyles2);
             }
             emElement.appendChild(parentElement.firstChild);

--- a/packages/elements/src/Text/utils/styles/copyParentColorToChild.ts
+++ b/packages/elements/src/Text/utils/styles/copyParentColorToChild.ts
@@ -71,7 +71,7 @@ export function copyColorStyleToTextNodes(element: Element): void {
           const firstChild = parentElement.firstChild;
 
           if (firstChild instanceof HTMLElement) {
-            const computedStyles = window.getComputedStyle(parentElement);
+            const computedStyles = window.getComputedStyle(firstChild);
 
             appenStylesToNode(firstChild, computedStyles);
           }


### PR DESCRIPTION
| Q  | A |
| ------------- | ------------- |
| Screenshot  | N/A |
| Related tickets	  | https://github.com/bagrinsergiu/MB-Support/issues/471|


### Changelog

* Fixed: Anthem link color

