### PR TITLE
Adjust top padding of the first element to 0

### DIFF
--- a/lib/MBMigration/Builder/Layout/Common/Concern/DanationsAble.php
+++ b/lib/MBMigration/Builder/Layout/Common/Concern/DanationsAble.php
@@ -162,6 +162,7 @@ trait DanationsAble
         $brizyDonationButton->getItemValueWithDepth(0)
             ->set_text($mbSection['settings']['sections']['donations']['text'] ?? 'MAKE A DONATION')
             ->set_linkExternal($mbSection['settings']['sections']['donations']['url'] ?? '#')
+            ->set_linkExternalBlank($this->detectLinkExternalBlank($mbSection, $browserPage))
             ->set_paddingType('ungrouped')
             ->set_paddingTop((int)$buttonStyles['padding-top'])
             ->set_paddingBottom((int)$buttonStyles['padding-bottom'])
@@ -185,6 +186,35 @@ trait DanationsAble
             ->set_colorPalette("");
 
         return $brizyDonationButton;
+    }
+
+    protected function detectLinkExternalBlank(array $mbSection, BrowserPageInterface $browserPage): string
+    {
+        $selector = '[data-id="'.$mbSection['sectionId'].'"] .donation > a';
+
+        $buttonTarget = $browserPage->evaluateScript(
+            'brizy.getAttributes',
+            [   //#donation-3697334 > div.content-wrapper.clearfix > div.text.donation.center > a
+                'selector' => $selector,
+                'attributeNames' => [
+                    'target',
+                ],
+            ]
+        );
+
+        if (isset($buttonTarget['error'])) {
+            return 'off';
+        }
+
+        $buttonTarget = $buttonTarget['data'];
+
+        if($buttonTarget['target'] == '_blank') {
+
+            return 'on';
+        } else {
+
+            return 'off';
+        }
     }
 
     protected function setHoveButtonStyles(

--- a/lib/MBMigration/Builder/Layout/Common/Concern/SectionStylesAble.php
+++ b/lib/MBMigration/Builder/Layout/Common/Concern/SectionStylesAble.php
@@ -18,11 +18,23 @@ trait SectionStylesAble
         array $additionalOptions = []
     ): void {
         $mbSectionItem = $data->getMbSection();
+        $options = [];
 
-        $options = [
-            'paddingTop' => $this->getTopPaddingOfTheFirstElement(),
-            'mobilePaddingTop' => $this->getMobileTopPaddingOfTheFirstElement(),
-        ];
+        if($this->getTopPaddingOfTheFirstElement() !== 0) {
+            $options = [
+                'paddingTop' => $this->getTopPaddingOfTheFirstElement(),
+            ];
+
+            $options = array_merge($options, $additionalOptions);
+        }
+
+        if($this->getMobileTopPaddingOfTheFirstElement() !== 0) {
+            $options = [
+                'mobilePaddingTop' => $this->getMobileTopPaddingOfTheFirstElement(),
+            ];
+
+            $options = array_merge($options, $additionalOptions);
+        }
 
         $options = array_merge($options, $additionalOptions);
 
@@ -103,9 +115,9 @@ trait SectionStylesAble
 
         // reset padding top for first section as in brizy there is no need for that padding.
         // In Voyage our fixed heared adds space
-        if (!is_null($pagePosition) && $pagePosition == 0) {
-            $sectionStyles['padding-top'] = 0;
-        }
+//        if (!is_null($pagePosition) && $pagePosition == 0) {
+//            $sectionStyles['padding-top'] = 0;
+//        }
 
         // set the background color paddings and margins
         $brizySection->getValue()

--- a/lib/MBMigration/Builder/Layout/Common/Elements/Text/GridLayoutElement.php
+++ b/lib/MBMigration/Builder/Layout/Common/Elements/Text/GridLayoutElement.php
@@ -33,9 +33,6 @@ abstract class GridLayoutElement extends AbstractElement
 
         $this->setTopPaddingOfTheFirstElement($data, $sectionItemComponent);
 
-        $sectionItemComponent->getValue()
-            ->set_paddingTop($this->getTopPaddingOfTheFirstElement());
-
         $elementContext = $data->instanceWithBrizyComponent($this->getHeaderComponent($brizySection));
         $this->handleRichTextHead($elementContext, $this->browserPage);
         $this->handleRichTextHeadFromItems($elementContext, $this->browserPage);

--- a/lib/MBMigration/Builder/Layout/Theme/Anthem/Elements/Events/EventFeturedLayout.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Anthem/Elements/Events/EventFeturedLayout.php
@@ -25,7 +25,7 @@ class EventFeturedLayout extends EventFeaturedLayoutElement
 
     protected function getTopPaddingOfTheFirstElement(): int
     {
-        return 50;
+        return 0;
     }
 
     protected function getMobileTopPaddingOfTheFirstElement(): int

--- a/lib/MBMigration/Builder/Layout/Theme/Anthem/Elements/Events/EventGalleryLayout.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Anthem/Elements/Events/EventGalleryLayout.php
@@ -7,7 +7,7 @@ class EventGalleryLayout extends \MBMigration\Builder\Layout\Common\Elements\Eve
 
     protected function getTopPaddingOfTheFirstElement(): int
     {
-        return 50;
+        return 0;
     }
 
     protected function getMobileTopPaddingOfTheFirstElement(): int

--- a/lib/MBMigration/Builder/Layout/Theme/Anthem/Elements/Events/EventLayoutElement.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Anthem/Elements/Events/EventLayoutElement.php
@@ -23,7 +23,7 @@ class EventLayoutElement extends \MBMigration\Builder\Layout\Common\Elements\Eve
 
     protected function getTopPaddingOfTheFirstElement(): int
     {
-        return 50;
+        return 0;
     }
 
     protected function getMobileTopPaddingOfTheFirstElement(): int

--- a/lib/MBMigration/Builder/Layout/Theme/Anthem/Elements/Events/EventListLayout.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Anthem/Elements/Events/EventListLayout.php
@@ -10,4 +10,9 @@ class EventListLayout extends \MBMigration\Builder\Layout\Common\Elements\Events
     {
         return $brizySection->getItemWithDepth(0, 1, 0, 0, 0);
     }
+
+    protected function getTopPaddingOfTheFirstElement(): int
+    {
+        return 0;
+    }
 }

--- a/lib/MBMigration/Builder/Layout/Theme/Anthem/Elements/Events/EventTileLayout.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Anthem/Elements/Events/EventTileLayout.php
@@ -13,7 +13,7 @@ class EventTileLayout extends \MBMigration\Builder\Layout\Common\Elements\Events
 
     protected function getTopPaddingOfTheFirstElement(): int
     {
-        return 50;
+        return 0;
     }
 
     protected function getMobileTopPaddingOfTheFirstElement(): int

--- a/lib/MBMigration/Builder/Layout/Theme/Anthem/Elements/Forms/Form.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Anthem/Elements/Forms/Form.php
@@ -35,7 +35,7 @@ class Form extends FormElement
 
     protected function getTopPaddingOfTheFirstElement(): int
     {
-        return 50;
+        return 0;
     }
 
     protected function getMobileTopPaddingOfTheFirstElement(): int

--- a/lib/MBMigration/Builder/Layout/Theme/Anthem/Elements/Forms/FullWidthForm.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Anthem/Elements/Forms/FullWidthForm.php
@@ -43,7 +43,7 @@ class FullWidthForm extends FormElement
 
     protected function getTopPaddingOfTheFirstElement(): int
     {
-        return 50;
+        return 0;
     }
 
     protected function getMobileTopPaddingOfTheFirstElement(): int

--- a/lib/MBMigration/Builder/Layout/Theme/Anthem/Elements/Forms/LeftForm.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Anthem/Elements/Forms/LeftForm.php
@@ -49,6 +49,11 @@ class LeftForm extends FormWithTextElement
         return $this->brizyKit['left-form'];
     }
 
+    protected function getTopPaddingOfTheFirstElement(): int
+    {
+        return 0;
+    }
+
     protected function getPropertiesMainSection(): array
     {
         return [

--- a/lib/MBMigration/Builder/Layout/Theme/Anthem/Elements/Forms/RightForm.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Anthem/Elements/Forms/RightForm.php
@@ -40,6 +40,11 @@ class RightForm extends FormWithTextElement
         return $this->handleRichTextItems($elementContext, $this->browserPage);
     }
 
+    protected function getTopPaddingOfTheFirstElement(): int
+    {
+        return 0;
+    }
+
     protected function getPropertiesMainSection(): array
     {
         return [

--- a/lib/MBMigration/Builder/Layout/Theme/Anthem/Elements/Gallery/GalleryLayoutElement.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Anthem/Elements/Gallery/GalleryLayoutElement.php
@@ -19,7 +19,7 @@ class GalleryLayoutElement extends \MBMigration\Builder\Layout\Common\Elements\G
 
     protected function getTopPaddingOfTheFirstElement(): int
     {
-        return 50;
+        return 0;
     }
 
     protected function getMobileTopPaddingOfTheFirstElement(): int

--- a/lib/MBMigration/Builder/Layout/Theme/Anthem/Elements/Groups/SmallGroupsListElement.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Anthem/Elements/Groups/SmallGroupsListElement.php
@@ -4,7 +4,10 @@ namespace MBMigration\Builder\Layout\Theme\Anthem\Elements\Groups;
 
 class SmallGroupsListElement extends \MBMigration\Builder\Layout\Common\Elements\Groups\SmallGroupsListElement
 {
-
+    protected function getTopPaddingOfTheFirstElement(): int
+    {
+        return 0;
+    }
     protected function getPropertiesMainSection(): array
     {
         return [

--- a/lib/MBMigration/Builder/Layout/Theme/Anthem/Elements/Prayer/PrayerFormElement.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Anthem/Elements/Prayer/PrayerFormElement.php
@@ -4,7 +4,10 @@ namespace MBMigration\Builder\Layout\Theme\Anthem\Elements\Prayer;
 
 class PrayerFormElement extends \MBMigration\Builder\Layout\Common\Elements\Prayer\PrayerFormElement
 {
-
+    protected function getTopPaddingOfTheFirstElement(): int
+    {
+        return 0;
+    }
     protected function getPropertiesMainSection(): array
     {
         return [

--- a/lib/MBMigration/Builder/Layout/Theme/Anthem/Elements/Sermons/MediaLayoutElement.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Anthem/Elements/Sermons/MediaLayoutElement.php
@@ -44,6 +44,11 @@ class MediaLayoutElement extends \MBMigration\Builder\Layout\Common\Elements\Ser
         return $brizySection;
     }
 
+    protected function getTopPaddingOfTheFirstElement(): int
+    {
+        return 0;
+    }
+
     protected function getPropertiesMainSection(): array
     {
         return [

--- a/lib/MBMigration/Builder/Layout/Theme/Anthem/Elements/Text/AccordionLayoutElement.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Anthem/Elements/Text/AccordionLayoutElement.php
@@ -187,7 +187,7 @@ class AccordionLayoutElement extends \MBMigration\Builder\Layout\Common\Elements
 
     protected function getTopPaddingOfTheFirstElement(): int
     {
-       return 50;
+       return 0;
     }
 
     protected function getMobileTopPaddingOfTheFirstElement(): int

--- a/lib/MBMigration/Builder/Layout/Theme/Anthem/Elements/Text/FullMediaElement.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Anthem/Elements/Text/FullMediaElement.php
@@ -45,7 +45,7 @@ class FullMediaElement extends FullMediaElementElement
 
     protected function getTopPaddingOfTheFirstElement(): int
     {
-        return 50;
+        return 0;
     }
 
     protected function getMobileTopPaddingOfTheFirstElement(): int

--- a/lib/MBMigration/Builder/Layout/Theme/Anthem/Elements/Text/FullText.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Anthem/Elements/Text/FullText.php
@@ -81,7 +81,7 @@ class FullText extends FullTextElement
 
     protected function getTopPaddingOfTheFirstElement(): int
     {
-        return 50;
+        return 0;
     }
 
     protected function getMobileTopPaddingOfTheFirstElement(): int

--- a/lib/MBMigration/Builder/Layout/Theme/Anthem/Elements/Text/GridLayoutElement.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Anthem/Elements/Text/GridLayoutElement.php
@@ -44,7 +44,7 @@ class GridLayoutElement extends \MBMigration\Builder\Layout\Common\Elements\Text
 
     protected function getTopPaddingOfTheFirstElement(): int
     {
-        return 50;
+        return 0;
     }
 
     protected function getMobileTopPaddingOfTheFirstElement(): int

--- a/lib/MBMigration/Builder/Layout/Theme/Anthem/Elements/Text/LeftMedia.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Anthem/Elements/Text/LeftMedia.php
@@ -69,6 +69,11 @@ class LeftMedia extends PhotoTextElement
         return $brizySection;
     }
 
+    protected function getTopPaddingOfTheFirstElement(): int
+    {
+        return 0;
+    }
+
     protected function getPropertiesMainSection(): array
     {
         return [

--- a/lib/MBMigration/Builder/Layout/Theme/Anthem/Elements/Text/LeftMediaCircle.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Anthem/Elements/Text/LeftMediaCircle.php
@@ -30,6 +30,11 @@ class LeftMediaCircle extends PhotoTextElement
         return $brizySection->getItemWithDepth(0);
     }
 
+    protected function getTopPaddingOfTheFirstElement(): int
+    {
+        return 0;
+    }
+
     protected function getPropertiesMainSection(): array
     {
         return [

--- a/lib/MBMigration/Builder/Layout/Theme/Anthem/Elements/Text/ListLayoutElement.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Anthem/Elements/Text/ListLayoutElement.php
@@ -63,6 +63,11 @@ class ListLayoutElement extends \MBMigration\Builder\Layout\Common\Elements\Text
         return $brizySection;
     }
 
+    protected function getTopPaddingOfTheFirstElement(): int
+    {
+        return 0;
+    }
+
     protected function getPropertiesMainSection(): array
     {
         return [

--- a/lib/MBMigration/Builder/Layout/Theme/Anthem/Elements/Text/RightMedia.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Anthem/Elements/Text/RightMedia.php
@@ -70,6 +70,11 @@ class RightMedia extends PhotoTextElement
         return $brizySection;
     }
 
+    protected function getTopPaddingOfTheFirstElement(): int
+    {
+        return 0;
+    }
+
     protected function getPropertiesMainSection(): array
     {
         return [

--- a/lib/MBMigration/Builder/Layout/Theme/Anthem/Elements/Text/TabsLayoutElement.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Anthem/Elements/Text/TabsLayoutElement.php
@@ -24,6 +24,11 @@ class TabsLayoutElement extends \MBMigration\Builder\Layout\Common\Elements\Text
         return $brizySection->getItemWithDepth(0, 1, 0, 0, 0);
     }
 
+    protected function getTopPaddingOfTheFirstElement(): int
+    {
+        return 0;
+    }
+
     protected function getPropertiesMainSection(): array
     {
         return [

--- a/lib/MBMigration/Builder/Layout/Theme/Anthem/Elements/Text/ThreeTopMediaCircle.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Anthem/Elements/Text/ThreeTopMediaCircle.php
@@ -32,6 +32,11 @@ class ThreeTopMediaCircle extends ThreeTopMediaCircleElement
         return $brizySection->getItemWithDepth(0);
     }
 
+    protected function getTopPaddingOfTheFirstElement(): int
+    {
+        return 0;
+    }
+
     protected function getPropertiesMainSection(): array
     {
         return [

--- a/lib/MBMigration/Builder/Layout/Theme/Anthem/Elements/Text/TwoHorizontalText.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Anthem/Elements/Text/TwoHorizontalText.php
@@ -86,6 +86,11 @@ class TwoHorizontalText extends TwoHorizontalTextElement
         return $brizySection->getItemWithDepth(0, 0, 1);
     }
 
+    protected function getTopPaddingOfTheFirstElement(): int
+    {
+        return 0;
+    }
+
     protected function getPropertiesMainSection(): array
     {
         return [

--- a/lib/MBMigration/Builder/Layout/Theme/Anthem/Elements/Text/TwoRightMediaCircle.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Anthem/Elements/Text/TwoRightMediaCircle.php
@@ -83,6 +83,11 @@ class TwoRightMediaCircle extends PhotoTextElement
         return $brizySection->getItemWithDepth(0);
     }
 
+    protected function getTopPaddingOfTheFirstElement(): int
+    {
+        return 0;
+    }
+
     protected function getPropertiesMainSection(): array
     {
         return [


### PR DESCRIPTION
Standardize the top padding for the first element across multiple layout elements by setting it to 0 instead of 50. This change affects various components like forms, text layouts, and event layouts ensuring uniform spacing across the application.