### PR TITLE
Change screenshot save path

### DIFF
--- a/lib/MBMigration/Browser/BrowserPagePHP.php
+++ b/lib/MBMigration/Browser/BrowserPagePHP.php
@@ -65,7 +65,7 @@ class BrowserPagePHP implements BrowserPageInterface
                     $pos = $this->page->mouse()->find($elementSelector)->getPosition();
                     $this->page->mouse()->move($pos['x'], $pos['y']);
                     usleep(1000);
-                    $this->page->screenshot()->saveToFile('/project/var/page.jpg');
+                    $this->page->screenshot()->saveToFile('/project/var/cache/page.jpg');
                     break;
                 case 'click':
                     $this->page->mouse()->find($elementSelector)->click();


### PR DESCRIPTION
Updated the path where the page screenshot is saved from '/project/var/page.jpg' to '/project/var/cache/page.jpg'. This change organizes screenshots better by placing them in the cache directory.