### PR TITLE
fix: set default donation button text if empty

### DIFF
--- a/lib/MBMigration/Builder/Layout/Common/Concern/DonationsAble.php
+++ b/lib/MBMigration/Builder/Layout/Common/Concern/DonationsAble.php
@@ -162,6 +162,10 @@ trait DonationsAble
                 break;
         }
 
+        if(empty($buttonText)){
+            $buttonText = 'MAKE A DONATION';
+        }
+
         $brizyDonationButton->getItemValueWithDepth(0)
             ->set_text($buttonText ?? 'MAKE A DONATION')
             ->set_linkExternal($mbSection['settings']['sections']['donations']['url'] ?? '#')


### PR DESCRIPTION
Add a check to initialize the donation button text to 'MAKE A DONATION' if it is empty. This ensures consistent button labeling and prevents display issues when the text is not provided.