### PR TITLE
feat: skip hidden grid items during migration

### DIFF
--- a/lib/MBMigration/Builder/Layout/Common/Elements/Text/GridLayoutElement.php
+++ b/lib/MBMigration/Builder/Layout/Common/Elements/Text/GridLayoutElement.php
@@ -120,6 +120,18 @@ abstract class GridLayoutElement extends AbstractElement
                                 $mbItem,
                                 $brizySectionItem
                             );
+
+                            $dataIdSelector = '[data-id="'.$mbItem['id'].'"]';
+
+                            $displayItem = $this->getDomElementStyles(
+                                $dataIdSelector,
+                                ['display'],
+                                $this->browserPage);
+
+                            if(trim($displayItem['display']) === 'none'){
+                                continue 2;
+                            }
+
                             $this->handleRichTextItem($elementContext, $this->browserPage, null, ['setEmptyText' => true]);
                             $this->handleDonations($elementContext, $this->browserPage, $this->brizyKit);
                             break;


### PR DESCRIPTION
Add logic to skip elements with 'display: none' in GridLayoutElement. This ensures that hidden items do not affect layout processing, improving migration efficiency and output accuracy.