### PR TITLE
feat: Enhance layout components with mobile alignment options

### DIFF
--- a/lib/MBMigration/Builder/BrizyComponent/BrizyComponent.php
+++ b/lib/MBMigration/Builder/BrizyComponent/BrizyComponent.php
@@ -351,6 +351,16 @@ class BrizyComponent implements JsonSerializable
 
         return $this;
     }
+    public function addMobileHorizontalContentAlign($verticalAlign = 'center'): BrizyComponent
+    {
+        if (!in_array($verticalAlign, ['center', 'left', 'right'])) {
+            $verticalAlign = 'center';
+        }
+
+        $this->getValue()->set('mobileHorizontalAlign', $verticalAlign);
+
+        return $this;
+    }
 
     public function addBgColor($hex, $opacity): BrizyComponent
     {

--- a/lib/MBMigration/Builder/Layout/Common/Elements/HeadElement.php
+++ b/lib/MBMigration/Builder/Layout/Common/Elements/HeadElement.php
@@ -167,9 +167,11 @@ abstract class HeadElement extends AbstractElement
         $headStyles
     ): BrizyComponent {
         $menuComponentValue = $component->getValue();
+        $projectName = $data->getThemeContext()->getProjectName();
         $menuComponentValue
             ->set('items', $this->createMenu($data->getBrizyMenuEntity()['list']))
-            ->set_menuSelected($data->getBrizyMenuEntity()['uid']);
+            ->set_menuSelected($data->getBrizyMenuEntity()['uid'])
+            ->set_mMenuTitle($projectName);
 
         // apply menu styles
         foreach ($headStyles['menu'] as $field => $value) {

--- a/lib/MBMigration/Builder/Layout/Common/ThemeContext.php
+++ b/lib/MBMigration/Builder/Layout/Common/ThemeContext.php
@@ -78,6 +78,7 @@ final class ThemeContext implements ThemeContextInterface
     private array $urlMap = [];
     private array $listSeries;
     private PageDto $pageDTO;
+    private string $projectName;
 
     public function __construct(
         string $layoutName,
@@ -97,7 +98,8 @@ final class ThemeContext implements ThemeContextInterface
         RootPalettesInterface $RootPalettes,
         BrowserInterface $browser,
         array $listSeries,
-        PageDto $pageDTO
+        PageDto $pageDTO,
+        string $projectName
     ) {
         $this->layoutName = $layoutName;
         $this->brizyKit = $brizyKit;
@@ -117,6 +119,7 @@ final class ThemeContext implements ThemeContextInterface
         $this->browser = $browser;
         $this->listSeries = $listSeries;
         $this->pageDTO = $pageDTO;
+        $this->projectName = $projectName;
     }
 
     public function getLayoutName(): string
@@ -214,6 +217,11 @@ final class ThemeContext implements ThemeContextInterface
     public function getPageDTO(): PageDto
     {
         return $this->pageDTO;
+    }
+
+    public function getProjectName(): string
+    {
+        return $this->projectName;
     }
 
     public function getBrizyComponentBuilder(): BrizyComponentBuilder

--- a/lib/MBMigration/Builder/Layout/Common/ThemeContextInterface.php
+++ b/lib/MBMigration/Builder/Layout/Common/ThemeContextInterface.php
@@ -47,4 +47,6 @@ interface ThemeContextInterface
     public function getPageDTO(): PageDto;
 
     public function getBrizyComponentBuilder(): BrizyComponentBuilder;
+
+    public function getProjectName(): string;
 }

--- a/lib/MBMigration/Builder/Layout/Theme/Ember/Elements/Head.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Ember/Elements/Head.php
@@ -3,6 +3,7 @@
 namespace MBMigration\Builder\Layout\Theme\Ember\Elements;
 
 use MBMigration\Builder\BrizyComponent\BrizyComponent;
+use MBMigration\Builder\Layout\Common\ElementContextInterface;
 use MBMigration\Builder\Layout\Common\Elements\HeadElement;
 
 class Head extends HeadElement
@@ -29,6 +30,45 @@ class Head extends HeadElement
     protected function getTargetMenuComponent(BrizyComponent $brizySection): BrizyComponent
     {
         return $brizySection->getItemWithDepth(0, 0, 1, 0, 0);
+    }
+
+    protected function internalTransformToItem(ElementContextInterface $data): BrizyComponent
+    {
+        $brizySection = parent::internalTransformToItem($data);
+
+        $sectionlogoOptions = [
+            'horizontalAlign' => 'center',
+            'mobileHorizontalAlign' => 'left',
+
+            'mobileMarginType' => 'grouped',
+            'mobileMargin' => 0,
+            'mobileMarginSuffix' => 'px',
+            'mobileMarginTop' => 0,
+            'mobileMarginTopSuffix' => 'px',
+            'mobileMarginRight' => 0,
+            'mobileMarginRightSuffix' => 'px',
+            'mobileMarginBottom' => 0,
+            'mobileMarginBottomSuffix' => 'px',
+            'mobileMarginLeft' => 0,
+            'mobileMarginLeftSuffix' => 'px',
+        ];
+
+        $brizySection->getItemWithDepth(0, 0, 0, 0)
+            ->addHorizontalContentAlign()
+            ->addMobileContentAlign()
+            ->addMobileMargin();
+
+        $brizySection->getItemWithDepth(0, 0, 1, 0)
+            ->addMobileMargin([11,11,11,0]);
+
+        foreach ($sectionlogoOptions as $option => $value) {
+            $nameOption = 'set_'.$option;
+            $brizySection->getItemWithDepth(0, 0, 0, 0)
+                ->getValue()
+                ->$nameOption($value);
+        }
+
+        return $brizySection;
     }
 
     public function getThemeMenuItemSelector(): array

--- a/lib/MBMigration/Builder/PageController.php
+++ b/lib/MBMigration/Builder/PageController.php
@@ -141,7 +141,8 @@ class PageController
                 $RootPalettesExtracted->extractRootPalettes(),
                 $this->browser,
                 $listSeries,
-                $this->pageDTO
+                $this->pageDTO,
+                $this->cache->get('title','settings') ?? ''
             );
 
             /**


### PR DESCRIPTION
Added method to align content horizontally on mobile for Brizy components. Integrated project name retrieval using ThemeContext to set menu titles dynamically. Additionally, improved the head section layout by introducing mobile alignment and margin adjustments for better responsiveness.