### PR TITLE
feat: add mobileWidth setting to GridLayoutElement

### DIFF
--- a/lib/MBMigration/Builder/Layout/Common/Elements/Text/GridLayoutElement.php
+++ b/lib/MBMigration/Builder/Layout/Common/Elements/Text/GridLayoutElement.php
@@ -79,7 +79,9 @@ abstract class GridLayoutElement extends AbstractElement
                     ->set_paddingTop((int)$styles['margin-top'])
                     ->set_paddingBottom((int)$styles['margin-bottom'])
                     ->set_paddingRight((int)$styles['margin-right'])
-                    ->set_paddingLeft((int)$styles['margin-left']);
+                    ->set_paddingLeft((int)$styles['margin-left'])
+
+                    ->set_mobileWidth(100);
 
                 foreach ($item['items'] as $mbItem) {
                     switch ($mbItem['category']) {


### PR DESCRIPTION
Introduce a new configuration option `mobileWidth` set to 100 for the GridLayoutElement. This change aims to improve mobile responsiveness by ensuring consistent element widths across devices. The additional setting will enhance layout flexibility and adaptability for different screen sizes.