### PR TITLE
feat: add support for custom CSS in Brizy components

### DIFF
--- a/lib/MBMigration/Builder/BrizyComponent/BrizyComponent.php
+++ b/lib/MBMigration/Builder/BrizyComponent/BrizyComponent.php
@@ -378,6 +378,12 @@ class BrizyComponent implements JsonSerializable
         return $this;
     }
 
+    public function addCustomCSS(string $ccsCustom): BrizyComponent
+    {
+        $this->getValue()->set('customCSS', $ccsCustom);
+        return $this;
+    }
+
     private function addConstructPadding($padding, $position, $prefix = '', $measureType = 'px'): void
     {
         $formattedPrefix = $prefix !== '' ? strtolower($prefix) : '';

--- a/lib/MBMigration/Builder/Layout/Theme/Ember/Elements/Head.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Ember/Elements/Head.php
@@ -53,6 +53,9 @@ class Head extends HeadElement
             'mobileMarginLeftSuffix' => 'px',
         ];
 
+        $brizySection->getItemWithDepth(0)
+            ->addCustomCSS('.brz-section__header{height: auto !important;}');
+
         $brizySection->getItemWithDepth(0, 0, 0, 0)
             ->addHorizontalContentAlign()
             ->addMobileContentAlign()


### PR DESCRIPTION
Introduce `addCustomCSS` method to BrizyComponent for adding custom CSS. Additionally, apply custom CSS for Brizy sections in the Ember theme Head element.