### PR TITLE
fix: update mobile padding bottom to 25px across elements

### DIFF
--- a/lib/MBMigration/Builder/Layout/Theme/Ember/Elements/Events/EventLayoutElement.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Ember/Elements/Events/EventLayoutElement.php
@@ -5,4 +5,21 @@ namespace MBMigration\Builder\Layout\Theme\Ember\Elements\Events;
 class EventLayoutElement extends \MBMigration\Builder\Layout\Common\Elements\Events\EventLayoutElement
 {
 
+    protected function getPropertiesMainSection(): array
+    {
+        return [
+            "mobilePaddingType"=> "ungrouped",
+            "mobilePadding" => 0,
+            "mobilePaddingSuffix" => "px",
+            "mobilePaddingTop" => 25,
+            "mobilePaddingTopSuffix" => "px",
+            "mobilePaddingRight" => 20,
+            "mobilePaddingRightSuffix" => "px",
+            "mobilePaddingBottom" => 25,
+            "mobilePaddingBottomSuffix" => "px",
+            "mobilePaddingLeft" => 20,
+            "mobilePaddingLeftSuffix" => "px",
+        ];
+    }
+
 }

--- a/lib/MBMigration/Builder/Layout/Theme/Ember/Elements/Sermons/MediaLayoutElement.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Ember/Elements/Sermons/MediaLayoutElement.php
@@ -35,7 +35,7 @@ class MediaLayoutElement extends \MBMigration\Builder\Layout\Common\Elements\Ser
             "mobilePaddingTopSuffix" => "px",
             "mobilePaddingRight" => 20,
             "mobilePaddingRightSuffix" => "px",
-            "mobilePaddingBottom" => 0,
+            "mobilePaddingBottom" => 25,
             "mobilePaddingBottomSuffix" => "px",
             "mobilePaddingLeft" => 20,
             "mobilePaddingLeftSuffix" => "px",

--- a/lib/MBMigration/Builder/Layout/Theme/Ember/Elements/Text/AccordionLayoutElement.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Ember/Elements/Text/AccordionLayoutElement.php
@@ -31,7 +31,7 @@ class AccordionLayoutElement extends \MBMigration\Builder\Layout\Common\Elements
             "mobilePaddingTopSuffix" => "px",
             "mobilePaddingRight" => 20,
             "mobilePaddingRightSuffix" => "px",
-            "mobilePaddingBottom" => 0,
+            "mobilePaddingBottom" => 25,
             "mobilePaddingBottomSuffix" => "px",
             "mobilePaddingLeft" => 20,
             "mobilePaddingLeftSuffix" => "px",

--- a/lib/MBMigration/Builder/Layout/Theme/Ember/Elements/Text/FourHorizontalText.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Ember/Elements/Text/FourHorizontalText.php
@@ -67,7 +67,7 @@ class FourHorizontalText extends AbstractElement
             "mobilePaddingTopSuffix" => "px",
             "mobilePaddingRight" => 20,
             "mobilePaddingRightSuffix" => "px",
-            "mobilePaddingBottom" => 0,
+            "mobilePaddingBottom" => 25,
             "mobilePaddingBottomSuffix" => "px",
             "mobilePaddingLeft" => 20,
             "mobilePaddingLeftSuffix" => "px",

--- a/lib/MBMigration/Builder/Layout/Theme/Ember/Elements/Text/FullText.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Ember/Elements/Text/FullText.php
@@ -32,7 +32,7 @@ class FullText extends FullTextElement
             "mobilePaddingTopSuffix" => "px",
             "mobilePaddingRight" => 20,
             "mobilePaddingRightSuffix" => "px",
-            "mobilePaddingBottom" => 0,
+            "mobilePaddingBottom" => 25,
             "mobilePaddingBottomSuffix" => "px",
             "mobilePaddingLeft" => 20,
             "mobilePaddingLeftSuffix" => "px",

--- a/lib/MBMigration/Builder/Layout/Theme/Ember/Elements/Text/LeftMedia.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Ember/Elements/Text/LeftMedia.php
@@ -47,7 +47,7 @@ class LeftMedia extends PhotoTextElement
             "mobilePaddingTopSuffix" => "px",
             "mobilePaddingRight" => 20,
             "mobilePaddingRightSuffix" => "px",
-            "mobilePaddingBottom" => 0,
+            "mobilePaddingBottom" => 25,
             "mobilePaddingBottomSuffix" => "px",
             "mobilePaddingLeft" => 20,
             "mobilePaddingLeftSuffix" => "px",

--- a/lib/MBMigration/Builder/Layout/Theme/Ember/Elements/Text/LeftMediaCircle.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Ember/Elements/Text/LeftMediaCircle.php
@@ -59,7 +59,7 @@ class LeftMediaCircle extends PhotoTextElement
             "mobilePaddingTopSuffix" => "px",
             "mobilePaddingRight" => 20,
             "mobilePaddingRightSuffix" => "px",
-            "mobilePaddingBottom" => 0,
+            "mobilePaddingBottom" => 25,
             "mobilePaddingBottomSuffix" => "px",
             "mobilePaddingLeft" => 20,
             "mobilePaddingLeftSuffix" => "px",

--- a/lib/MBMigration/Builder/Layout/Theme/Ember/Elements/Text/ListLayoutElement.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Ember/Elements/Text/ListLayoutElement.php
@@ -46,7 +46,7 @@ class ListLayoutElement extends \MBMigration\Builder\Layout\Common\Elements\Text
             "mobilePaddingTopSuffix" => "px",
             "mobilePaddingRight" => 20,
             "mobilePaddingRightSuffix" => "px",
-            "mobilePaddingBottom" => 0,
+            "mobilePaddingBottom" => 25,
             "mobilePaddingBottomSuffix" => "px",
             "mobilePaddingLeft" => 20,
             "mobilePaddingLeftSuffix" => "px",

--- a/lib/MBMigration/Builder/Layout/Theme/Ember/Elements/Text/RightMedia.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Ember/Elements/Text/RightMedia.php
@@ -47,7 +47,7 @@ class RightMedia extends PhotoTextElement
             "mobilePaddingTopSuffix" => "px",
             "mobilePaddingRight" => 20,
             "mobilePaddingRightSuffix" => "px",
-            "mobilePaddingBottom" => 0,
+            "mobilePaddingBottom" => 25,
             "mobilePaddingBottomSuffix" => "px",
             "mobilePaddingLeft" => 20,
             "mobilePaddingLeftSuffix" => "px",

--- a/lib/MBMigration/Builder/Layout/Theme/Ember/Elements/Text/RightMediaCircle.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Ember/Elements/Text/RightMediaCircle.php
@@ -52,7 +52,7 @@ class RightMediaCircle extends PhotoTextElement
             "mobilePaddingTopSuffix" => "px",
             "mobilePaddingRight" => 20,
             "mobilePaddingRightSuffix" => "px",
-            "mobilePaddingBottom" => 0,
+            "mobilePaddingBottom" => 25,
             "mobilePaddingBottomSuffix" => "px",
             "mobilePaddingLeft" => 20,
             "mobilePaddingLeftSuffix" => "px",

--- a/lib/MBMigration/Builder/Layout/Theme/Ember/Elements/Text/TabsLayoutElement.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Ember/Elements/Text/TabsLayoutElement.php
@@ -39,7 +39,7 @@ class TabsLayoutElement extends \MBMigration\Builder\Layout\Common\Elements\Text
             "mobilePaddingTopSuffix" => "px",
             "mobilePaddingRight" => 20,
             "mobilePaddingRightSuffix" => "px",
-            "mobilePaddingBottom" => 0,
+            "mobilePaddingBottom" => 25,
             "mobilePaddingBottomSuffix" => "px",
             "mobilePaddingLeft" => 20,
             "mobilePaddingLeftSuffix" => "px",

--- a/lib/MBMigration/Builder/Layout/Theme/Ember/Elements/Text/ThreeBottomMediaCircle.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Ember/Elements/Text/ThreeBottomMediaCircle.php
@@ -63,7 +63,7 @@ class ThreeBottomMediaCircle extends FullTextElement
             "mobilePaddingTopSuffix" => "px",
             "mobilePaddingRight" => 20,
             "mobilePaddingRightSuffix" => "px",
-            "mobilePaddingBottom" => 0,
+            "mobilePaddingBottom" => 25,
             "mobilePaddingBottomSuffix" => "px",
             "mobilePaddingLeft" => 20,
             "mobilePaddingLeftSuffix" => "px",


### PR DESCRIPTION
Adjusted `mobilePaddingBottom` values from 0 to 25px for multiple layout elements to improve mobile styling consistency. Added missing `getPropertiesMainSection` method in `EventLayoutElement` for better configuration handling.