### PR TITLE
standardize top padding for layout elements

### DIFF
--- a/lib/MBMigration/Builder/Layout/Theme/Ember/Elements/Sermons/MediaLayoutElement.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Ember/Elements/Sermons/MediaLayoutElement.php
@@ -17,7 +17,7 @@ class MediaLayoutElement extends \MBMigration\Builder\Layout\Common\Elements\Ser
 
     protected function getTopPaddingOfTheFirstElement(): int
     {
-        return 0;
+        return 95;
     }
 
     protected function getMobileTopPaddingOfTheFirstElement(): int

--- a/lib/MBMigration/Builder/Layout/Theme/Ember/Elements/Text/AccordionLayoutElement.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Ember/Elements/Text/AccordionLayoutElement.php
@@ -16,6 +16,11 @@ class AccordionLayoutElement extends \MBMigration\Builder\Layout\Common\Elements
         return $brizySection->getItemWithDepth(0, 1, 0, 0, 0);
     }
 
+    protected function getTopPaddingOfTheFirstElement(): int
+    {
+        return 95;
+    }
+
     protected function getMobileTopPaddingOfTheFirstElement(): int
     {
         return 95;

--- a/lib/MBMigration/Builder/Layout/Theme/Ember/Elements/Text/FourHorizontalText.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Ember/Elements/Text/FourHorizontalText.php
@@ -52,6 +52,11 @@ class FourHorizontalText extends AbstractElement
         return $brizySection;
     }
 
+    protected function getTopPaddingOfTheFirstElement(): int
+    {
+        return 95;
+    }
+
     protected function getMobileTopPaddingOfTheFirstElement(): int
     {
         return 95;

--- a/lib/MBMigration/Builder/Layout/Theme/Ember/Elements/Text/FullText.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Ember/Elements/Text/FullText.php
@@ -17,6 +17,11 @@ class FullText extends FullTextElement
         return $brizySection->getItemWithDepth(0);
     }
 
+    protected function getTopPaddingOfTheFirstElement(): int
+    {
+        return 95;
+    }
+
     protected function getMobileTopPaddingOfTheFirstElement(): int
     {
         return 95;

--- a/lib/MBMigration/Builder/Layout/Theme/Ember/Elements/Text/GridLayoutElement.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Ember/Elements/Text/GridLayoutElement.php
@@ -34,7 +34,7 @@ class GridLayoutElement extends \MBMigration\Builder\Layout\Common\Elements\Text
 
     protected function getTopPaddingOfTheFirstElement(): int
     {
-        return 80;
+        return 95;
     }
 
     protected function getMobileTopPaddingOfTheFirstElement(): int

--- a/lib/MBMigration/Builder/Layout/Theme/Ember/Elements/Text/LeftMedia.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Ember/Elements/Text/LeftMedia.php
@@ -32,6 +32,11 @@ class LeftMedia extends PhotoTextElement
             ->addPaddingRight(45, '%');
     }
 
+    protected function getTopPaddingOfTheFirstElement(): int
+    {
+        return 95;
+    }
+
     protected function getMobileTopPaddingOfTheFirstElement(): int
     {
         return 95;

--- a/lib/MBMigration/Builder/Layout/Theme/Ember/Elements/Text/LeftMediaCircle.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Ember/Elements/Text/LeftMediaCircle.php
@@ -43,6 +43,11 @@ class LeftMediaCircle extends PhotoTextElement
             ->set_widthSuffix((strpos($width,'%')===true)?'%':'pix');
     }
 
+    protected function getTopPaddingOfTheFirstElement(): int
+    {
+        return 95;
+    }
+
     protected function getMobileTopPaddingOfTheFirstElement(): int
     {
         return 95;

--- a/lib/MBMigration/Builder/Layout/Theme/Ember/Elements/Text/ListLayoutElement.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Ember/Elements/Text/ListLayoutElement.php
@@ -31,6 +31,11 @@ class ListLayoutElement extends \MBMigration\Builder\Layout\Common\Elements\Text
         return $brizySection;
     }
 
+    protected function getTopPaddingOfTheFirstElement(): int
+    {
+        return 95;
+    }
+
     protected function getMobileTopPaddingOfTheFirstElement(): int
     {
         return 95;

--- a/lib/MBMigration/Builder/Layout/Theme/Ember/Elements/Text/RightMedia.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Ember/Elements/Text/RightMedia.php
@@ -32,6 +32,11 @@ class RightMedia extends PhotoTextElement
             ->addPaddingLeft(45, '%');
     }
 
+    protected function getTopPaddingOfTheFirstElement(): int
+    {
+        return 95;
+    }
+
     protected function getMobileTopPaddingOfTheFirstElement(): int
     {
         return 95;

--- a/lib/MBMigration/Builder/Layout/Theme/Ember/Elements/Text/RightMediaCircle.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Ember/Elements/Text/RightMediaCircle.php
@@ -42,6 +42,16 @@ class RightMediaCircle extends PhotoTextElement
             ->set_widthSuffix((strpos($height,'%')===true)?'%':'pix');
     }
 
+    protected function getTopPaddingOfTheFirstElement(): int
+    {
+        return 95;
+    }
+
+    protected function getMobileTopPaddingOfTheFirstElement(): int
+    {
+        return 95;
+    }
+
     protected function getPropertiesMainSection(): array
     {
         return [

--- a/lib/MBMigration/Builder/Layout/Theme/Ember/Elements/Text/TabsLayoutElement.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Ember/Elements/Text/TabsLayoutElement.php
@@ -24,6 +24,11 @@ class TabsLayoutElement extends \MBMigration\Builder\Layout\Common\Elements\Text
         return $brizySection->getItemWithDepth(0, 1, 0, 0, 0);
     }
 
+    protected function getTopPaddingOfTheFirstElement(): int
+    {
+        return 95;
+    }
+
     protected function getMobileTopPaddingOfTheFirstElement(): int
     {
         return 95;

--- a/lib/MBMigration/Builder/Layout/Theme/Ember/Elements/Text/ThreeBottomMediaCircle.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Ember/Elements/Text/ThreeBottomMediaCircle.php
@@ -48,6 +48,11 @@ class ThreeBottomMediaCircle extends FullTextElement
         return $brizySection;
     }
 
+    protected function getTopPaddingOfTheFirstElement(): int
+    {
+        return 95;
+    }
+
     protected function getMobileTopPaddingOfTheFirstElement(): int
     {
         return 95;


### PR DESCRIPTION
feat: standardize top padding for layout elements

Added or updated `getTopPaddingOfTheFirstElement` method across multiple layout elements to return a consistent value of 95. This ensures uniform spacing and a more cohesive layout presentation throughout the application.
