### PR TITLE
feat: add button rendering logic to layout elements

### DIFF
--- a/lib/MBMigration/Builder/Layout/Common/Elements/AbstractElement.php
+++ b/lib/MBMigration/Builder/Layout/Common/Elements/AbstractElement.php
@@ -84,6 +84,15 @@ abstract class AbstractElement implements ElementInterface
 
         return true;
     }
+    protected function canShowButton($sectionData): bool
+    {
+        $sectionCategory = $sectionData['category'];
+        if (isset($sectionData['settings']['sections'][$sectionCategory]['show_buttons'])) {
+            return $sectionData['settings']['sections'][$sectionCategory]['show_buttons'];
+        }
+
+        return true;
+    }
 
     protected function transformItem(ElementContextInterface $data, BrizyComponent $brizySection, array $params = []): BrizyComponent
     {

--- a/lib/MBMigration/Builder/Layout/Theme/Ember/Elements/Text/FourHorizontalText.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Ember/Elements/Text/FourHorizontalText.php
@@ -31,6 +31,9 @@ class FourHorizontalText extends AbstractElement
         $bodies = $this->sortItems(array_filter($mbSection['items'], function ($item) {
             return $item['item_type'] == 'body' && $item['category'] == 'text';
         }));
+        $buttons = $this->sortItems(array_filter($mbSection['items'], function ($item) {
+            return $item['category'] == 'button';
+        }));
 
         $columnJson = json_decode($this->brizyKit['column'], true);
 
@@ -41,8 +44,12 @@ class FourHorizontalText extends AbstractElement
             $this->handleRichTextItem($tmpElementContext, $this->browserPage);
             $tmpElementContext = $data->instanceWithBrizyComponentAndMBSection($bodies[$i], $brizyColumn);
             $this->handleRichTextItem($tmpElementContext, $this->browserPage);
-            $buttonSelector = $mbSection['sectionId'];
-            $this->handleRichTextItem($tmpElementContext, $this->browserPage, "[data-id='$buttonSelector'] .group-$i");
+            if($this->canShowButton($mbSection)){
+                $buttonSelector = $mbSection['sectionId'];
+                $tmpElementContext = $data->instanceWithBrizyComponentAndMBSection($buttons[$i], $brizyColumn);
+                $this->handleRichTextItem($tmpElementContext, $this->browserPage, "[data-id='$buttonSelector'] .group-$i");
+            }
+
             $columns[] = $brizyColumn;
         }
         $brizySection->getItemValueWithDepth(0,0)->add_items($columns);


### PR DESCRIPTION
Introduce a `canShowButton` method to control the visibility of buttons based on section settings. Update `FourHorizontalText` to include buttons in the layout when applicable, improving flexibility and customization in the layout rendering.