### PR TITLE
feat: add previewTypography support to event details layout

### DIFF
--- a/lib/MBMigration/Builder/BrizyComponent/BrizyComponent.php
+++ b/lib/MBMigration/Builder/BrizyComponent/BrizyComponent.php
@@ -407,6 +407,35 @@ class BrizyComponent implements JsonSerializable
         return $this;
     }
 
+    public function previewTypography(): BrizyComponent
+    {
+        $bgColor = [
+            "previewTypographyFontStyle" => "",
+            "previewTypographyFontFamily" => "lato",
+            "previewTypographyFontFamilyType" => "google",
+            "previewTypographyFontSize" => 16,
+            "previewTypographyFontSizeSuffix" => "px",
+            "previewTypographyFontWeight" => 400,
+            "previewTypographyLetterSpacing" => 0,
+            "previewTypographyLineHeight" => 1.9,
+            "previewTypographyVariableFontWeight" => 400,
+            "previewTypographyFontWidth" => 100,
+            "previewTypographyFontSoftness" => 0,
+            "previewTypographyBold" => false,
+            "previewTypographyItalic" => false,
+            "previewTypographyUnderline" => false,
+            "previewTypographyStrike" => false,
+            "previewTypographyUppercase" => false,
+            "previewTypographyLowercase" => false
+        ];
+
+        foreach ($bgColor as $key => $value) {
+            $this->getValue()->set($key, $value);
+        }
+
+        return $this;
+    }
+
     public function addCustomCSS(string $ccsCustom): BrizyComponent
     {
         $this->getValue()->set('customCSS', $ccsCustom);

--- a/lib/MBMigration/Builder/Layout/Common/Elements/Events/EventDetailsPageLayout.php
+++ b/lib/MBMigration/Builder/Layout/Common/Elements/Events/EventDetailsPageLayout.php
@@ -214,7 +214,9 @@ class EventDetailsPageLayout
                 ->$properties($value);
         }
 
-        $detailsSection->getItemWithDepth(0, 1, 0, 0, 0)->titleTypography();
+        $detailsSection->getItemWithDepth(0, 1, 0, 0, 0)
+            ->titleTypography()
+            ->previewTypography();
 
         foreach ($sectionProperties2Margin as $key => $value) {
             $properties = 'set_'.$key;


### PR DESCRIPTION
Introduced a new `previewTypography` method in `BrizyComponent` to handle typography styling for preview elements. Integrated this functionality within `EventDetailsPageLayout` to enhance typography customization options.