### PR TITLE
feat: add handler for item text container component padding

### DIFF
--- a/lib/MBMigration/Builder/Layout/Common/Elements/Text/ListLayoutElement.php
+++ b/lib/MBMigration/Builder/Layout/Common/Elements/Text/ListLayoutElement.php
@@ -60,6 +60,8 @@ abstract class ListLayoutElement extends AbstractElement
                 ->set_paddingRight((int)$styles['margin-right'])
                 ->set_paddingLeft((int)$styles['margin-left']);
 
+            $this->handleItemTextContainerComponent($brizySectionItem);
+
             foreach ($item['items'] as $mbItem) {
                 if ($mbItem['item_type'] == 'title') {
                     $elementContext = $data->instanceWithBrizyComponentAndMBSection(
@@ -133,6 +135,11 @@ abstract class ListLayoutElement extends AbstractElement
     ): BrizyComponent;
 
     abstract protected function transformListItem(ElementContextInterface $data, BrizyComponent $brizySection, array $params = []): BrizyComponent;
+
+    protected function handleItemTextContainerComponent(BrizyComponent $brizySection): void
+    {
+
+    }
 
     protected function getPropertiesMainSection(): array
     {

--- a/lib/MBMigration/Builder/Layout/Theme/Voyage/Elements/Text/ListLayoutElement.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Voyage/Elements/Text/ListLayoutElement.php
@@ -26,6 +26,11 @@ class ListLayoutElement extends \MBMigration\Builder\Layout\Common\Elements\Text
         return $brizySection;
     }
 
+    protected function handleItemTextContainerComponent(BrizyComponent $brizySection): void
+    {
+        $brizySection->addPadding(35, 0, 35, 0);
+    }
+
     protected function getTopPaddingOfTheFirstElement(): int
     {
         return 80;


### PR DESCRIPTION
Introduced a new method to manage padding for item text container components in `ListLayoutElement`. This ensures consistent padding application across relevant items in both `Voyage` and `Common` themes.