### PR TITLE
feat(padding): add reusable handleItemRowComponent method

### DIFF
--- a/lib/MBMigration/Builder/Layout/Common/Elements/Text/GridLayoutElement.php
+++ b/lib/MBMigration/Builder/Layout/Common/Elements/Text/GridLayoutElement.php
@@ -42,7 +42,6 @@ abstract class GridLayoutElement extends AbstractElement
         $rowJson = json_decode($this->brizyKit['row'], true);
         $itemJson = json_decode($this->brizyKit['item'], true);
 
-
         $accordionItems = $this->getItemsByCategory($mbSection,'list');
         $accordionItems = $this->sortItems($accordionItems);
         $itemsChunks = array_chunk($accordionItems, $this->getItemsPerRow());
@@ -55,7 +54,7 @@ abstract class GridLayoutElement extends AbstractElement
                 ->set_size($rowWidth)
                 ->set_mobileSize(100);
 
-            $brizySectionRow->addPadding(10,10,0,10);
+            $this->handleItemRowComponent($brizySectionRow);
 
             foreach ($row as $item) {
 
@@ -218,6 +217,13 @@ abstract class GridLayoutElement extends AbstractElement
     protected function getTypeItemImageComponent(): string
     {
        return 'bg';
+    }
+
+    protected function handleItemRowComponent(BrizyComponent $brizyComponent):void
+    {
+        $brizyComponent
+            ->addPadding(20,0,20,0)
+            ->addMobilePadding(10);
     }
 
     protected function getPropertiesMainSection(): array

--- a/lib/MBMigration/Builder/Layout/Theme/Anthem/Elements/Text/GridLayoutElement.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Anthem/Elements/Text/GridLayoutElement.php
@@ -25,6 +25,13 @@ class GridLayoutElement extends \MBMigration\Builder\Layout\Common\Elements\Text
         return $brizyComponent->getItemWithDepth(0);
     }
 
+    protected function handleItemRowComponent(BrizyComponent $brizyComponent):void
+    {
+        $brizyComponent
+            ->addPadding(20,10,20,10)
+            ->addMobilePadding(10);
+    }
+
     protected function getPropertiesMainSection(): array
     {
         return [

--- a/lib/MBMigration/Builder/Layout/Theme/Ember/Elements/Text/GridLayoutElement.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Ember/Elements/Text/GridLayoutElement.php
@@ -26,11 +26,17 @@ class GridLayoutElement extends \MBMigration\Builder\Layout\Common\Elements\Text
         return $brizyComponent->getItemWithDepth(0, 0);
     }
 
+    protected function handleItemRowComponent(BrizyComponent $brizyComponent):void
+    {
+        $brizyComponent
+            ->addPadding(20,0,20,0)
+            ->addMobilePadding(10);
+    }
+
     protected function getTypeItemImageComponent(): string
     {
         return 'image';
     }
-
 
     protected function getTopPaddingOfTheFirstElement(): int
     {

--- a/lib/MBMigration/Builder/Layout/Theme/Voyage/Elements/Text/GridLayoutElement.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Voyage/Elements/Text/GridLayoutElement.php
@@ -26,6 +26,13 @@ class GridLayoutElement extends \MBMigration\Builder\Layout\Common\Elements\Text
         return $brizyComponent->getItemWithDepth(0,0);
     }
 
+    protected function handleItemRowComponent(BrizyComponent $brizyComponent):void
+    {
+        $brizyComponent
+            ->addPadding(20,0,20,0)
+            ->addMobilePadding(10);
+    }
+
     protected function getTopPaddingOfTheFirstElement(): int
     {
         return 80;


### PR DESCRIPTION
Introduced a new handleItemRowComponent method to standardize padding behavior across GridLayoutElement classes. Refactored existing padding logic to utilize this method, improving consistency and maintainability.