### PR TITLE
refactor: update CSS selectors and comment out unused code

### DIFF
--- a/lib/MBMigration/Browser/BrowserPagePHP.php
+++ b/lib/MBMigration/Browser/BrowserPagePHP.php
@@ -62,7 +62,7 @@ class BrowserPagePHP implements BrowserPageInterface
             switch ($eventNameMethod) {
                 case 'hover':
                     $this->page->screenshot()->saveToFile('/project/var/cache/page.jpg');
-                    $this->page->mouse()->move(1, 1);
+//                    $this->page->mouse()->move(1, 1);
                     $pos = $this->page->mouse()->find($elementSelector, 0)->getPosition();
                     $this->page->mouse()->move($pos['x'], $pos['y']);
                     usleep(1000);

--- a/lib/MBMigration/Builder/Layout/Theme/Ember/Elements/Head.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Ember/Elements/Head.php
@@ -81,17 +81,17 @@ class Head extends HeadElement
 
     public function getThemeParentMenuItemSelector(): array
     {
-        return ["selector" => "#main-navigation>ul>li.has-sub", "pseudoEl" => ""];
+        return ["selector" => "#main-navigation ul li.has-sub", "pseudoEl" => ""];
     }
 
     public function getThemeSubMenuNotSelectedItemSelector(): array
     {#main-navigation > ul:nth-child(1) > li:nth-child(2) > ul > li:nth-child(1) > a
-        return ["selector" => "#main-navigation>ul>li.has-sub>ul.sub-navigation>li>a", "pseudoEl" => ""];
+        return ["selector" => "#main-navigation ul li.has-sub ul.sub-navigation li a", "pseudoEl" => ""];
     }
 
     public function getThemeSubMenuItemClassSelected(): array
     {
-        return ["selector" => "#selected-sub-navigation > ul > li", "className" => "selected"];
+        return ["selector" => "#selected-sub-navigation ul li", "className" => "selected"];
     }
 
     public function getThemeMenuItemBgSelector(): array
@@ -143,6 +143,6 @@ class Head extends HeadElement
 
     protected function getThemeSubMenuItemSelector(): array
     {
-        return ["selector" => "#main-navigation>ul>li.has-sub>ul.sub-navigation>li>a", "pseudoEl" => ""];
+        return ["selector" => "#main-navigation ul li.has-sub ul.sub-navigation li a", "pseudoEl" => ""];
     }
 }


### PR DESCRIPTION
Updated CSS selectors to simplify and remove unnecessary '>' combinators for clarity and consistency. Commented out an unused mouse movement call that was redundant in the hover event handling method.