### PR TITLE
feat: add getNodeAttribute utility and enhance handleLink logic

### DIFF
--- a/lib/MBMigration/Builder/Layout/Common/Concern/CssPropertyExtractorAware.php
+++ b/lib/MBMigration/Builder/Layout/Common/Concern/CssPropertyExtractorAware.php
@@ -188,4 +188,17 @@ trait CssPropertyExtractorAware
         return $this->getDomElementStyles($selectorSectionStyles, $styles, $browserPage, $families, $default_fonts);
     }
 
+    public function getNodeAttribute(BrowserPageInterface $browserPage, string $selector, string $attributes)
+    {
+        $result = $browserPage->evaluateScript(
+            "brizy.dom.getNodeAttribute",
+            [
+                'selector' => $selector,
+                'attributeName' => $attributes,
+            ]
+        );
+
+        return $result['data'] ?? false;
+    }
+
 }

--- a/lib/MBMigration/Builder/Layout/Common/Concern/RichTextAble.php
+++ b/lib/MBMigration/Builder/Layout/Common/Concern/RichTextAble.php
@@ -280,18 +280,28 @@ trait RichTextAble
                     ->set_mobileHeightSuffix($sizeUnit);
             }
 
-            $this->handleLink($mbSectionItem, $brizyComponent);
+            $this->handleLink(
+                $mbSectionItem,
+                $brizyComponent,
+                '[data-id="'.$mbSectionItemId.'"] div.photo-container a',
+                $browserPage);
         }
 
         return $brizyComponent;
     }
 
-    private function handleLink($mbSectionItem, $brizyComponent)
+    private function handleLink($mbSectionItem, $brizyComponent, $selector, $browserPage)
     {
         if ($mbSectionItem['new_window']) {
             $mbSectionItem['new_window'] = 'on';
         } else {
-            $mbSectionItem['new_window'] = 'off';
+            $mbSectionItem['new_window'] = $this->openNewTab(
+                $this->getNodeAttribute(
+                    $browserPage,
+                    $selector,
+                    'target'
+                )
+            );
         }
 
         if ($mbSectionItem['link'] != '') {
@@ -568,6 +578,18 @@ trait RichTextAble
             $result[$key] = $this->extractInteger($size);
         }
         return $result;
+    }
+
+    private function openNewTab(string $targetValue): string
+    {
+        switch ($targetValue) {
+            case '_blank':
+                return 'on';
+            case '_self':
+            default:
+                return 'off';
+        }
+
     }
 
 }

--- a/lib/MBMigration/Builder/Layout/Common/Elements/Text/GridLayoutElement.php
+++ b/lib/MBMigration/Builder/Layout/Common/Elements/Text/GridLayoutElement.php
@@ -199,7 +199,12 @@ abstract class GridLayoutElement extends AbstractElement
                 ->$method($value);
         }
 
-        $this->handleLink($mbSectionItem, $brizyComponent);
+        $this->handleLink(
+            $mbSectionItem,
+            $brizyComponent,
+            '[data-id="'.$mbSectionItem['id'].'"] .photo-container a',
+            $this->browserPage
+        );
     }
 
     abstract protected function getItemsPerRow(): int;

--- a/lib/MBMigration/Builder/Layout/Theme/Anthem/Assets/dist/index.js
+++ b/lib/MBMigration/Builder/Layout/Theme/Anthem/Assets/dist/index.js
@@ -989,6 +989,38 @@
     }
   });
 
+  // ../../../../../../../packages/elements/src/Dom/getNodeAttribute.ts
+  var getNodeAttribute;
+  var init_getNodeAttribute = __esm({
+    "../../../../../../../packages/elements/src/Dom/getNodeAttribute.ts"() {
+      "use strict";
+      init_getData();
+      getNodeAttribute = ({ selector, attributeName }) => {
+        try {
+          const element = document.querySelector(selector ?? "");
+          if (!element) {
+            return {
+              data: false
+            };
+          }
+          const value = element.getAttribute(attributeName);
+          if (value) {
+            return createData({
+              data: value
+            });
+          }
+          return {
+            data: false
+          };
+        } catch (error) {
+          return {
+            data: false
+          };
+        }
+      };
+    }
+  });
+
   // src/Dom/index.ts
   var dom;
   var init_Dom = __esm({
@@ -1000,13 +1032,15 @@
       init_getRootPropertyStyles();
       init_hasNode();
       init_removeNodeClass();
+      init_getNodeAttribute();
       dom = {
         hasNode,
         getNodeText,
         getRootPropertyStyles,
         detectSubpalette,
         addNodeClass,
-        removeNodeClass
+        removeNodeClass,
+        getNodeAttribute
       };
     }
   });

--- a/lib/MBMigration/Builder/Layout/Theme/Anthem/Assets/src/Dom/index.ts
+++ b/lib/MBMigration/Builder/Layout/Theme/Anthem/Assets/src/Dom/index.ts
@@ -4,6 +4,7 @@ import { getNodeText } from "elements/src/Dom/getNodeText";
 import { getRootPropertyStyles } from "elements/src/Dom/getRootPropertyStyles";
 import { hasNode } from "elements/src/Dom/hasNode";
 import { removeNodeClass } from "elements/src/Dom/removeNodeClass";
+import { getNodeAttribute } from "elements/src/Dom/getNodeAttribute";
 
 export const dom = {
   hasNode,
@@ -11,5 +12,6 @@ export const dom = {
   getRootPropertyStyles,
   detectSubpalette,
   addNodeClass,
-  removeNodeClass
+  removeNodeClass,
+  getNodeAttribute
 };

--- a/packages/elements/src/Dom/getNodeAttribute.ts
+++ b/packages/elements/src/Dom/getNodeAttribute.ts
@@ -1,0 +1,30 @@
+import {createData} from "../utils/getData";
+
+export const getNodeAttribute = ({selector, attributeName}) => {
+  try {
+    const element = document.querySelector(selector ?? "");
+
+    if (!element) {
+      return {
+        data: false
+      };
+    }
+
+    const value = element.getAttribute(attributeName);
+
+    if (value) {
+      return createData({
+        data: value
+      })
+    }
+
+    return {
+      data: false
+    }
+
+  } catch (error) {
+    return {
+      data: false
+    }
+  }
+};


### PR DESCRIPTION
Introduce a new `getNodeAttribute` utility function to retrieve DOM node attributes. Updated the `handleLink` logic to utilize this utility for determining link behavior based on the `target` attribute, allowing more dynamic and accurate handling of links in different contexts.