### PR TITLE
Add mobile margin styles for accordion headings

### DIFF
--- a/lib/MBMigration/Builder/Layout/Theme/Bloom/Elements/Text/AccordionLayoutElement.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Bloom/Elements/Text/AccordionLayoutElement.php
@@ -159,9 +159,27 @@ class AccordionLayoutElement extends \MBMigration\Builder\Layout\Common\Elements
             "mobilePaddingLeftSuffix" => "px",
         ];
 
+        $accordionHeadTextStyle = [
+            'mobileMarginType' => 'ungrouped',
+            'mobileMarginTop' => 0,
+            'mobileMarginTopSuffix' => 'px',
+            'mobileMarginBottom' => 0,
+            'mobileMarginBottomSuffix' => 'px',
+            'mobileMarginRight' => 10,
+            'mobileMarginRightSuffix' => 'px',
+            'mobileMarginLeft' => 10,
+            'mobileMarginLeftSuffix' => 'px',
+        ];
+
         foreach ($accordionElementStyle as $key => $value) {
             $method = "set_".$key;
             $brizySection->getItemWithDepth(0,1)->getValue()
+                ->$method($value);
+        }
+
+        foreach ($accordionHeadTextStyle as $key => $value) {
+            $method = "set_".$key;
+            $brizySection->getItemWithDepth(0,0)->getValue()
                 ->$method($value);
         }
 


### PR DESCRIPTION
This commit introduces a new style configuration, `accordionHeadTextStyle`, to set specific mobile margin values for accordion headings. These styles include top, bottom, left, and right margins with appropriate suffixes, applied via a foreach loop targeting accordion heading elements.