### PR TITLE
fix: adjust top padding calculations across multiple elements

### DIFF
--- a/lib/MBMigration/Builder/Layout/Theme/Bloom/Elements/Events/EventGalleryLayout.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Bloom/Elements/Events/EventGalleryLayout.php
@@ -30,7 +30,7 @@ class EventGalleryLayout extends \MBMigration\Builder\Layout\Common\Elements\Eve
     {
         $dtoPageStyle = $this->pageTDO->getPageStyleDetails();
 
-        return 50 + $dtoPageStyle['headerHeight'];
+        return 25 + $dtoPageStyle['headerHeight'];
     }
 
     protected function getMobileTopPaddingOfTheFirstElement(): int

--- a/lib/MBMigration/Builder/Layout/Theme/Bloom/Elements/Events/EventLayoutElement.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Bloom/Elements/Events/EventLayoutElement.php
@@ -35,7 +35,7 @@ class EventLayoutElement extends \MBMigration\Builder\Layout\Common\Elements\Eve
     {
         $dtoPageStyle = $this->pageTDO->getPageStyleDetails();
 
-        return 50 + $dtoPageStyle['headerHeight'];
+        return 25 + $dtoPageStyle['headerHeight'];
     }
 
     protected function getMobileTopPaddingOfTheFirstElement(): int

--- a/lib/MBMigration/Builder/Layout/Theme/Bloom/Elements/Forms/FullWidthForm.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Bloom/Elements/Forms/FullWidthForm.php
@@ -28,7 +28,7 @@ class FullWidthForm extends FormElement
     {
         $dtoPageStyle = $this->pageTDO->getPageStyleDetails();
 
-        return 50 + $dtoPageStyle['headerHeight'];
+        return 25 + $dtoPageStyle['headerHeight'];
     }
 
     protected function getMobileTopPaddingOfTheFirstElement(): int

--- a/lib/MBMigration/Builder/Layout/Theme/Bloom/Elements/Forms/LeftForm.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Bloom/Elements/Forms/LeftForm.php
@@ -45,7 +45,7 @@ class LeftForm extends FormWithTextElement
     {
         $dtoPageStyle = $this->pageTDO->getPageStyleDetails();
 
-        return 50 + $dtoPageStyle['headerHeight'];
+        return 25 + $dtoPageStyle['headerHeight'];
     }
 
     protected function getMobileTopPaddingOfTheFirstElement(): int

--- a/lib/MBMigration/Builder/Layout/Theme/Bloom/Elements/Forms/RightForm.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Bloom/Elements/Forms/RightForm.php
@@ -44,7 +44,7 @@ class RightForm extends FormWithTextElement
     {
         $dtoPageStyle = $this->pageTDO->getPageStyleDetails();
 
-        return 50 + $dtoPageStyle['headerHeight'];
+        return 25 + $dtoPageStyle['headerHeight'];
     }
 
     protected function getMobileTopPaddingOfTheFirstElement(): int

--- a/lib/MBMigration/Builder/Layout/Theme/Bloom/Elements/Prayer/PrayerFormElement.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Bloom/Elements/Prayer/PrayerFormElement.php
@@ -9,7 +9,7 @@ class PrayerFormElement extends \MBMigration\Builder\Layout\Common\Elements\Pray
     {
         $dtoPageStyle = $this->pageTDO->getPageStyleDetails();
 
-        return 50 + $dtoPageStyle['headerHeight'];
+        return 25 + $dtoPageStyle['headerHeight'];
     }
 
     protected function getMobileTopPaddingOfTheFirstElement(): int

--- a/lib/MBMigration/Builder/Layout/Theme/Bloom/Elements/Semons/MediaLayoutElement.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Bloom/Elements/Semons/MediaLayoutElement.php
@@ -35,7 +35,7 @@ class MediaLayoutElement extends \MBMigration\Builder\Layout\Common\Elements\Ser
     {
         $dtoPageStyle = $this->pageTDO->getPageStyleDetails();
 
-        return 50 + $dtoPageStyle['headerHeight'];
+        return 25 + $dtoPageStyle['headerHeight'];
     }
 
     protected function getMobileTopPaddingOfTheFirstElement(): int

--- a/lib/MBMigration/Builder/Layout/Theme/Bloom/Elements/Text/AccordionLayoutElement.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Bloom/Elements/Text/AccordionLayoutElement.php
@@ -189,7 +189,7 @@ class AccordionLayoutElement extends \MBMigration\Builder\Layout\Common\Elements
     {
         $dtoPageStyle = $this->pageTDO->getPageStyleDetails();
 
-        return 50 + $dtoPageStyle['headerHeight'];
+        return 25 + $dtoPageStyle['headerHeight'];
     }
 
     protected function getPropertiesMainSection(): array

--- a/lib/MBMigration/Builder/Layout/Theme/Bloom/Elements/Text/FullMediaElement.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Bloom/Elements/Text/FullMediaElement.php
@@ -57,7 +57,7 @@ class FullMediaElement extends FullMediaElementElement
     {
         $dtoPageStyle = $this->pageTDO->getPageStyleDetails();
 
-        return 50 + $dtoPageStyle['headerHeight'];
+        return 25 + $dtoPageStyle['headerHeight'];
     }
 
     protected function getMobileTopPaddingOfTheFirstElement(): int

--- a/lib/MBMigration/Builder/Layout/Theme/Bloom/Elements/Text/FullText.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Bloom/Elements/Text/FullText.php
@@ -21,7 +21,7 @@ class FullText extends FullTextElement
     {
         $dtoPageStyle = $this->pageTDO->getPageStyleDetails();
 
-        return 50 + $dtoPageStyle['headerHeight'];
+        return 30 + $dtoPageStyle['headerHeight'];
     }
 
     protected function getMobileTopPaddingOfTheFirstElement(): int

--- a/lib/MBMigration/Builder/Layout/Theme/Bloom/Elements/Text/GridLayoutElement.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Bloom/Elements/Text/GridLayoutElement.php
@@ -29,7 +29,7 @@ class GridLayoutElement extends \MBMigration\Builder\Layout\Common\Elements\Text
     {
         $dtoPageStyle = $this->pageTDO->getPageStyleDetails();
 
-        return 50 + $dtoPageStyle['headerHeight'];
+        return 25 + $dtoPageStyle['headerHeight'];
     }
 
     protected function getMobileTopPaddingOfTheFirstElement(): int

--- a/lib/MBMigration/Builder/Layout/Theme/Bloom/Elements/Text/LeftMedia.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Bloom/Elements/Text/LeftMedia.php
@@ -62,7 +62,7 @@ class LeftMedia extends PhotoTextElement
     {
         $dtoPageStyle = $this->pageTDO->getPageStyleDetails();
 
-        return 50 + $dtoPageStyle['headerHeight'];
+        return 25 + $dtoPageStyle['headerHeight'];
     }
 
     protected function getMobileTopPaddingOfTheFirstElement(): int

--- a/lib/MBMigration/Builder/Layout/Theme/Bloom/Elements/Text/LeftMediaCircle.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Bloom/Elements/Text/LeftMediaCircle.php
@@ -62,7 +62,7 @@ class LeftMediaCircle extends PhotoTextElement
     {
         $dtoPageStyle = $this->pageTDO->getPageStyleDetails();
 
-        return 50 + $dtoPageStyle['headerHeight'];
+        return 25 + $dtoPageStyle['headerHeight'];
     }
 
     protected function getMobileTopPaddingOfTheFirstElement(): int

--- a/lib/MBMigration/Builder/Layout/Theme/Bloom/Elements/Text/ListLayoutElement.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Bloom/Elements/Text/ListLayoutElement.php
@@ -40,7 +40,7 @@ class ListLayoutElement extends \MBMigration\Builder\Layout\Common\Elements\Text
     {
         $dtoPageStyle = $this->pageTDO->getPageStyleDetails();
 
-        return 50 + $dtoPageStyle['headerHeight'];
+        return 25 + $dtoPageStyle['headerHeight'];
     }
 
     protected function getMobileTopPaddingOfTheFirstElement(): int

--- a/lib/MBMigration/Builder/Layout/Theme/Bloom/Elements/Text/RightMedia.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Bloom/Elements/Text/RightMedia.php
@@ -62,7 +62,7 @@ class RightMedia extends PhotoTextElement
     {
         $dtoPageStyle = $this->pageTDO->getPageStyleDetails();
 
-        return 50 + $dtoPageStyle['headerHeight'];
+        return 25 + $dtoPageStyle['headerHeight'];
     }
 
     protected function getMobileTopPaddingOfTheFirstElement(): int

--- a/lib/MBMigration/Builder/Layout/Theme/Bloom/Elements/Text/RightMediaCircle.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Bloom/Elements/Text/RightMediaCircle.php
@@ -62,7 +62,7 @@ class RightMediaCircle extends PhotoTextElement
     {
         $dtoPageStyle = $this->pageTDO->getPageStyleDetails();
 
-        return 50 + $dtoPageStyle['headerHeight'];
+        return 25 + $dtoPageStyle['headerHeight'];
     }
 
     protected function getMobileTopPaddingOfTheFirstElement(): int

--- a/lib/MBMigration/Builder/Layout/Theme/Bloom/Elements/Text/TabsLayoutElement.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Bloom/Elements/Text/TabsLayoutElement.php
@@ -28,7 +28,7 @@ class TabsLayoutElement extends \MBMigration\Builder\Layout\Common\Elements\Text
     {
         $dtoPageStyle = $this->pageTDO->getPageStyleDetails();
 
-        return 50 + $dtoPageStyle['headerHeight'];
+        return 25 + $dtoPageStyle['headerHeight'];
     }
 
     protected function getMobileTopPaddingOfTheFirstElement(): int

--- a/lib/MBMigration/Builder/Layout/Theme/Bloom/Elements/Text/TwoRightMediaCircle.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Bloom/Elements/Text/TwoRightMediaCircle.php
@@ -118,7 +118,7 @@ class TwoRightMediaCircle extends PhotoTextElement
     {
         $dtoPageStyle = $this->pageTDO->getPageStyleDetails();
 
-        return 50 + $dtoPageStyle['headerHeight'];
+        return 25 + $dtoPageStyle['headerHeight'];
     }
 
     protected function getMobileTopPaddingOfTheFirstElement(): int

--- a/lib/MBMigration/Builder/PageController.php
+++ b/lib/MBMigration/Builder/PageController.php
@@ -48,7 +48,13 @@ class PageController
     private int $projectID_Brizy;
     private PageDto $pageDTO;
 
-    public function __construct(MBProjectDataCollector $MBProjectDataCollector, BrizyAPI $brizyAPI, QueryBuilder $QueryBuilder, LoggerInterface $logger, $projectID_Brizy)
+    public function __construct(
+        MBProjectDataCollector $MBProjectDataCollector,
+        BrizyAPI $brizyAPI,
+        QueryBuilder $QueryBuilder,
+        LoggerInterface $logger,
+        $projectID_Brizy
+    )
     {
         $this->cache = VariableCache::getInstance();
         $this->pageDTO = new PageDTO();


### PR DESCRIPTION
Reduced the top padding offset for header height from 50 to 25 (or 30 for FullText) across various layout elements. This ensures better alignment and consistent spacing within themes. Also reformatted the PageController constructor for improved readability.