### PR TITLE
Add additional color configuration options for EventGallery

### DIFF
--- a/lib/MBMigration/Builder/Layout/Common/Elements/Events/EventGalleryLayout.php
+++ b/lib/MBMigration/Builder/Layout/Common/Elements/Events/EventGalleryLayout.php
@@ -108,6 +108,10 @@ abstract class EventGalleryLayout extends AbstractElement
             'previewColorOpacity' => 1,
             'previewColorPalette' => '',
 
+            'colorHex' => $sectionPalette['text'],
+            'colorOpacity' => 1,
+            'colorPalette' => '',
+
             'hoverPreviewColorHex' => '#f8f8f8',
             'hoverPreviewColorOpacity' => 0.8,
             'hoverPreviewColorPalette' => '',
@@ -235,6 +239,14 @@ abstract class EventGalleryLayout extends AbstractElement
             'layoutViewTypographyFontFamily' => $fonts,
             'layoutViewTypographyFontStyle' => '',
             'layoutViewTypographyFontFamilyType' => 'upload',
+
+            "metaLinksColorHex" => $sectionPalette['link'],
+            "metaLinksColorOpacity" => 1,
+            "metaLinksColorPalette" => "",
+
+            "hoverMetaLinksColorHex" => $sectionPalette['link'],
+            "hoverMetaLinksColorOpacity" => 0.75,
+            "hoverMetaLinksColorPalette" => "",
         ];
 
         foreach ($sectionProperties as $key => $value) {


### PR DESCRIPTION
Introduce support for `colorHex`, `colorOpacity`, and related hover configurations to enhance customization of gallery sections. Also adds new properties for `metaLinks` and their hover states, improving flexibility in link styling.