### PR TITLE
feat: add height configuration for Brizy components

### DIFF
--- a/lib/MBMigration/Builder/BrizyComponent/BrizyComponent.php
+++ b/lib/MBMigration/Builder/BrizyComponent/BrizyComponent.php
@@ -743,5 +743,20 @@ class BrizyComponent implements JsonSerializable
         return $this;
     }
 
+    public function addHeight(int $int, string $string = 'px')
+    {
+        $this->getValue()->set('height', $int);
+        $this->getValue()->set('heightSuffix', $string);
+        return $this;
+    }
+
+    public function addSectionHeight(int $int, string $suffix = 'vh')
+    {
+        $this->getValue()->set('sectionHeight', $int);
+        $this->getValue()->set('fullHeight', 'custom');
+        $this->getValue()->set('sectionHeightSuffix', $suffix);
+        return $this;
+    }
+
 
 }

--- a/lib/MBMigration/Builder/Layout/Theme/Ember/Elements/Sermons/MediaLayoutElement.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Ember/Elements/Sermons/MediaLayoutElement.php
@@ -12,6 +12,8 @@ class MediaLayoutElement extends \MBMigration\Builder\Layout\Common\Elements\Ser
     {
         $brizySection = parent::internalTransformToItem($data);
 
+        $brizySection->addSectionHeight(100);
+
         return $brizySection;
     }
 


### PR DESCRIPTION
Introduced `addHeight` and `addSectionHeight` methods to BrizyComponent for customizing height settings. Updated MediaLayoutElement to set a default section height of 100vh during transformation.