### PR TITLE
feat: add customizable donations button padding options

### DIFF
--- a/lib/MBMigration/Builder/Layout/Common/Elements/AbstractElement.php
+++ b/lib/MBMigration/Builder/Layout/Common/Elements/AbstractElement.php
@@ -202,6 +202,16 @@ abstract class AbstractElement implements ElementInterface
         ];
     }
 
+    protected function getDonationsButtonOptions(): array
+    {
+        return [
+            'mobilePaddingTop' => 0,
+            'mobilePaddingRight' => 0,
+            'mobilePaddingBottom' => 0,
+            'mobilePaddingLeft' => 0,
+        ];
+    }
+
     private function initialBehavior(ElementContextInterface $data): void
     {
         $this->getBasicStyleForButton($data);

--- a/lib/MBMigration/Builder/Layout/Common/Elements/Text/FullMediaElementElement.php
+++ b/lib/MBMigration/Builder/Layout/Common/Elements/Text/FullMediaElementElement.php
@@ -8,6 +8,7 @@ use MBMigration\Builder\Layout\Common\Concern\RichTextAble;
 use MBMigration\Builder\Layout\Common\Concern\SectionStylesAble;
 use MBMigration\Builder\Layout\Common\Elements\AbstractElement;
 use MBMigration\Builder\Layout\Common\ElementContextInterface;
+use MBMigration\Builder\Layout\Common\Exception\BadJsonProvided;
 
 abstract class FullMediaElementElement extends AbstractElement
 {
@@ -15,6 +16,9 @@ abstract class FullMediaElementElement extends AbstractElement
     use SectionStylesAble;
     use DonationsAble;
 
+    /**
+     * @throws BadJsonProvided
+     */
     protected function internalTransformToItem(ElementContextInterface $data): BrizyComponent
     {
         $brizySection = new BrizyComponent(json_decode($this->brizyKit['main'], true));
@@ -30,7 +34,7 @@ abstract class FullMediaElementElement extends AbstractElement
         $brizySectionItemComponent = $this->getTextContainerComponent($brizySection);
         $elementContext = $data->instanceWithBrizyComponent($brizySectionItemComponent);
         $this->handleRichTextItems($elementContext, $this->browserPage);
-        $this->handleDonations($elementContext, $this->browserPage, $this->brizyKit);
+        $this->handleDonations($elementContext, $this->browserPage, $this->brizyKit, $this->getDonationsButtonOptions());
 
         $brizyImageWrapperComponent = $this->getImageWrapperComponent($brizySection);
         $brizyImageComponent = $this->getImageComponent($brizySection);

--- a/lib/MBMigration/Builder/Layout/Common/Elements/Text/FullTextElement.php
+++ b/lib/MBMigration/Builder/Layout/Common/Elements/Text/FullTextElement.php
@@ -36,7 +36,7 @@ abstract class FullTextElement extends AbstractElement
 
         $elementContext = $data->instanceWithBrizyComponent($textContainerComponent);
         $this->handleRichTextItems($elementContext, $this->browserPage);
-        $this->handleDonations($elementContext, $this->browserPage, $this->brizyKit);
+        $this->handleDonations($elementContext, $this->browserPage, $this->brizyKit, $this->getDonationsButtonOptions());
 
         // not sure if this must be there or in a concrete theme
         // the image in the bg is not always correctly fitted

--- a/lib/MBMigration/Builder/Layout/Common/Elements/Text/GridLayoutElement.php
+++ b/lib/MBMigration/Builder/Layout/Common/Elements/Text/GridLayoutElement.php
@@ -141,7 +141,7 @@ abstract class GridLayoutElement extends AbstractElement
                             }
 
                             $this->handleRichTextItem($elementContext, $this->browserPage, null, ['setEmptyText' => true]);
-                            $this->handleDonations($elementContext, $this->browserPage, $this->brizyKit);
+                            $this->handleDonations($elementContext, $this->browserPage, $this->brizyKit, $this->getDonationsButtonOptions());
                             break;
                     }
                 }

--- a/lib/MBMigration/Builder/Layout/Common/Elements/Text/ListLayoutElement.php
+++ b/lib/MBMigration/Builder/Layout/Common/Elements/Text/ListLayoutElement.php
@@ -104,7 +104,7 @@ abstract class ListLayoutElement extends AbstractElement
                         $mbItem,
                         $this->getItemTextContainerComponent($brizySectionItem, $photoPosition)
                     );
-                    $this->handleDonations($elementContext, $this->browserPage, $this->brizyKit);
+                    $this->handleDonations($elementContext, $this->browserPage, $this->brizyKit, $this->getDonationsButtonOptions());
                 }
             }
 

--- a/lib/MBMigration/Builder/Layout/Common/Elements/Text/PhotoTextElement.php
+++ b/lib/MBMigration/Builder/Layout/Common/Elements/Text/PhotoTextElement.php
@@ -64,7 +64,7 @@ abstract class PhotoTextElement extends AbstractElement
         }
 
         $elementContext = $data->instanceWithBrizyComponent($this->getTextComponent($brizySection));
-        $this->handleDonations($elementContext, $this->browserPage, $this->brizyKit);
+        $this->handleDonations($elementContext, $this->browserPage, $this->brizyKit, $this->getDonationsButtonOptions());
 
         $sectionItemComponent = $this->getSectionItemComponent($brizySection);
 

--- a/lib/MBMigration/Builder/Layout/Theme/Voyage/Elements/Text/FullMediaElement.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Voyage/Elements/Text/FullMediaElement.php
@@ -38,6 +38,16 @@ class FullMediaElement extends FullMediaElementElement
         return 25;
     }
 
+    protected function getDonationsButtonOptions(): array
+    {
+        return [
+            'mobilePaddingTop' => 10,
+            'mobilePaddingRight' => 0,
+            'mobilePaddingBottom' => 10,
+            'mobilePaddingLeft' => 0,
+        ];
+    }
+
     protected function getPropertiesMainSection(): array
     {
         return [

--- a/lib/MBMigration/Builder/Layout/Theme/Voyage/Elements/Text/FullText.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Voyage/Elements/Text/FullText.php
@@ -32,6 +32,16 @@ class FullText extends FullTextElement
         return $brizySection;
     }
 
+    protected function getDonationsButtonOptions(): array
+    {
+        return [
+            'mobilePaddingTop' => 10,
+            'mobilePaddingRight' => 0,
+            'mobilePaddingBottom' => 10,
+            'mobilePaddingLeft' => 0,
+        ];
+    }
+
     protected function getPropertiesMainSection(): array
     {
         return [

--- a/lib/MBMigration/Builder/Layout/Theme/Voyage/Elements/Text/GridLayoutElement.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Voyage/Elements/Text/GridLayoutElement.php
@@ -31,6 +31,16 @@ class GridLayoutElement extends \MBMigration\Builder\Layout\Common\Elements\Text
             ->getItemWithDepth(0,0);
     }
 
+    protected function getDonationsButtonOptions(): array
+    {
+        return [
+            'mobilePaddingTop' => 10,
+            'mobilePaddingRight' => 0,
+            'mobilePaddingBottom' => 10,
+            'mobilePaddingLeft' => 0,
+        ];
+    }
+
     protected function handleItemRowComponent(BrizyComponent $brizyComponent):void
     {
         $brizyComponent

--- a/lib/MBMigration/Builder/Layout/Theme/Voyage/Elements/Text/LeftMedia.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Voyage/Elements/Text/LeftMedia.php
@@ -43,6 +43,16 @@ class LeftMedia extends PhotoTextElement
         return 25;
     }
 
+    protected function getDonationsButtonOptions(): array
+    {
+        return [
+            'mobilePaddingTop' => 10,
+            'mobilePaddingRight' => 0,
+            'mobilePaddingBottom' => 10,
+            'mobilePaddingLeft' => 0,
+        ];
+    }
+
     protected function getPropertiesMainSection(): array
     {
         return [

--- a/lib/MBMigration/Builder/Layout/Theme/Voyage/Elements/Text/LeftMediaOverlap.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Voyage/Elements/Text/LeftMediaOverlap.php
@@ -46,6 +46,16 @@ class LeftMediaOverlap extends PhotoTextElement
         return 25;
     }
 
+    protected function getDonationsButtonOptions(): array
+    {
+        return [
+            'mobilePaddingTop' => 10,
+            'mobilePaddingRight' => 0,
+            'mobilePaddingBottom' => 10,
+            'mobilePaddingLeft' => 0,
+        ];
+    }
+
     protected function getPropertiesMainSection(): array
     {
         return [

--- a/lib/MBMigration/Builder/Layout/Theme/Voyage/Elements/Text/ListLayoutElement.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Voyage/Elements/Text/ListLayoutElement.php
@@ -41,6 +41,16 @@ class ListLayoutElement extends \MBMigration\Builder\Layout\Common\Elements\Text
         return 25;
     }
 
+    protected function getDonationsButtonOptions(): array
+    {
+        return [
+            'mobilePaddingTop' => 10,
+            'mobilePaddingRight' => 0,
+            'mobilePaddingBottom' => 10,
+            'mobilePaddingLeft' => 0,
+        ];
+    }
+
     protected function getPropertiesMainSection(): array
     {
         return [

--- a/lib/MBMigration/Builder/Layout/Theme/Voyage/Elements/Text/RightMedia.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Voyage/Elements/Text/RightMedia.php
@@ -72,6 +72,16 @@ class RightMedia extends PhotoTextElement
         return 25;
     }
 
+    protected function getDonationsButtonOptions(): array
+    {
+        return [
+            'mobilePaddingTop' => 10,
+            'mobilePaddingRight' => 0,
+            'mobilePaddingBottom' => 10,
+            'mobilePaddingLeft' => 0,
+        ];
+    }
+
     protected function getPropertiesMainSection(): array
     {
         return [

--- a/lib/MBMigration/Builder/Layout/Theme/Voyage/Elements/Text/RightMediaOverlap.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Voyage/Elements/Text/RightMediaOverlap.php
@@ -46,6 +46,16 @@ class RightMediaOverlap extends PhotoTextElement
         return 25;
     }
 
+    protected function getDonationsButtonOptions(): array
+    {
+        return [
+            'mobilePaddingTop' => 10,
+            'mobilePaddingRight' => 0,
+            'mobilePaddingBottom' => 10,
+            'mobilePaddingLeft' => 0,
+        ];
+    }
+
     protected function getPropertiesMainSection(): array
     {
         return [


### PR DESCRIPTION
Introduces a `getDonationsButtonOptions` method to allow specifying custom mobile padding for donation buttons in various elements. Default and theme-specific padding configurations are now supported, improving layout flexibility.