### PR TITLE
fix: correct parameter usage in URL generation logic

### DIFF
--- a/lib/MBMigration/Builder/PageController.php
+++ b/lib/MBMigration/Builder/PageController.php
@@ -230,7 +230,7 @@ class PageController
             if (!empty($page['child'])){
                 $this->pageMapping($page['child'],$mapping, $domain);
             }
-            $mapping['/'.PathSlugExtractor::getFullUrl($page['slug'], true)] = $domain.'/'.$page['slug'];
+            $mapping['/'.PathSlugExtractor::getFullUrlById($page['id'], true)] = $domain.'/'.$page['slug'];
         }
     }
 

--- a/lib/MBMigration/Builder/Utils/PathSlugExtractor.php
+++ b/lib/MBMigration/Builder/Utils/PathSlugExtractor.php
@@ -24,7 +24,7 @@ class PathSlugExtractor
         return $urlBuilder->setPath($pathPages)->build();
     }
 
-    public static function getFullUrlById($slug, bool $getPath = false): string
+    public static function getFullUrlById($id, bool $getPath = false): string
     {
         $cache = VariableCache::getInstance();
         $treePages = $cache->get('ParentPages');
@@ -33,7 +33,7 @@ class PathSlugExtractor
 
         $urlBuilder = new UrlBuilder($domain);
 
-        $pathPages = self::getOrderedPathString($treePages, $slug, 'id');
+        $pathPages = self::getOrderedPathString($treePages, $id, 'id');
 
         if ($getPath){
             return $pathPages;


### PR DESCRIPTION
Replaced 'slug' with 'id' in the path-building functions to ensure proper URL generation based on unique identifiers. This resolves potential issues with duplicate or ambiguous slugs in the system.