### PR TITLE
refactor: remove unused variables in GalleryLayoutElement

### DIFF
--- a/lib/MBMigration/Builder/Layout/Common/Elements/Gallery/GalleryLayoutElement.php
+++ b/lib/MBMigration/Builder/Layout/Common/Elements/Gallery/GalleryLayoutElement.php
@@ -25,9 +25,7 @@ abstract class GalleryLayoutElement extends AbstractElement
 
         $mbSection = $data->getMbSection();
 
-        $aa =  json_encode($mbSection);
         $brizySection = new BrizyComponent(json_decode($this->brizyKit['main'], true));
-        $itemImage = new BrizyComponent(json_decode($this->brizyKit['itemImage'], true));
 
         $sectionItemComponent = $this->getSectionItemComponent($brizySection);
         $elementContext = $data->instanceWithBrizyComponent($sectionItemComponent);


### PR DESCRIPTION
Removed redundant and unused variables from GalleryLayoutElement to improve code clarity and maintainability. This cleanup eliminates unnecessary json_encode and BrizyComponent instantiations.