### PR TITLE
feat: add active menu item selector for theme navigation

### DIFF
--- a/lib/MBMigration/Builder/Layout/Common/Elements/HeadElement.php
+++ b/lib/MBMigration/Builder/Layout/Common/Elements/HeadElement.php
@@ -244,9 +244,10 @@ abstract class HeadElement extends AbstractElement
         // -------------------------------------
         $menuItemStyles = $this->browserPage->evaluateScript('brizy.getMenuItem', [
             'itemSelector' => $menuItemSelector,
-            'itemMobileSelector' => $itemMobileSelector,
+            'itemActiveSelector' => $this->getThemeMenuItemActiveSelector(),
             'itemBgSelector' => $this->getThemeMenuItemBgSelector(),
             'itemPaddingSelector' => $this->getThemeMenuItemPaddingSelector(),
+            'itemMobileSelector' => $itemMobileSelector,
             'itemMobileBtnSelector' => $this->getThemeMobileBtnSelector(),
             'itemMobileNavSelector' => $this->getThemeMobileNavSelector(),
             'families' => $families,
@@ -433,4 +434,6 @@ abstract class HeadElement extends AbstractElement
     abstract public function getThemeMenuItemBgSelector(): array;
 
     abstract public function getThemeMenuItemPaddingSelector(): array;
+
+    abstract public function getThemeMenuItemActiveSelector(): array;
 }

--- a/lib/MBMigration/Builder/Layout/Theme/Anthem/Elements/Head.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Anthem/Elements/Head.php
@@ -304,6 +304,11 @@ class Head extends HeadElement
         return ["selector" => "#main-navigation>ul>li:not(.selected) a", "pseudoEl" => ""];
     }
 
+    public function getThemeMenuItemActiveSelector(): array
+    {
+        return ["selector" => "#main-navigation>ul>li.selected a", "pseudoEl" => ""];
+    }
+
     public function getThemeParentMenuItemSelector(): array
     {
         return ["selector" => "#main-navigation", "pseudoEl" => ""];

--- a/lib/MBMigration/Builder/Layout/Theme/August/Elements/Head.php
+++ b/lib/MBMigration/Builder/Layout/Theme/August/Elements/Head.php
@@ -206,6 +206,11 @@ class Head extends HeadElement
 
     }
 
+    public function getThemeMenuItemActiveSelector(): array
+    {
+        return ["selector" => "#main-navigation>ul>li.selected a", "pseudoEl" => ""];
+    }
+
     public function getThemeMenuItemSelector(): array
     {
         return ["selector" => "#main-navigation>ul>li:not(.selected) a", "pseudoEl" => ""];

--- a/lib/MBMigration/Builder/Layout/Theme/Aurora/Elements/Head.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Aurora/Elements/Head.php
@@ -219,6 +219,11 @@ class Head extends HeadElement
 
     }
 
+    public function getThemeMenuItemActiveSelector(): array
+    {
+        return ["selector" => "#main-navigation>ul>li.selected a", "pseudoEl" => ""];
+    }
+
     public function getThemeMenuItemSelector(): array
     {
         return ["selector" => "#main-navigation>ul>li:not(.selected) a", "pseudoEl" => ""];

--- a/lib/MBMigration/Builder/Layout/Theme/Bloom/Elements/Head.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Bloom/Elements/Head.php
@@ -38,6 +38,11 @@ class Head extends HeadElement
         return $brizySection->getItemWithDepth(0);
     }
 
+    public function getThemeMenuItemActiveSelector(): array
+    {
+        return ["selector" => "#main-navigation>ul>li.selected a", "pseudoEl" => ""];
+    }
+
     public function getThemeMenuItemSelector(): array
     {
         return ["selector" => "#main-navigation>ul>li:not(.selected)>a", "pseudoEl" => ""];

--- a/lib/MBMigration/Builder/Layout/Theme/Boulevard/Elements/Head.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Boulevard/Elements/Head.php
@@ -206,6 +206,11 @@ class Head extends HeadElement
 
     }
 
+    public function getThemeMenuItemActiveSelector(): array
+    {
+        return ["selector" => "#main-navigation>ul>li.selected a", "pseudoEl" => ""];
+    }
+
     public function getThemeMenuItemSelector(): array
     {
         return ["selector" => "#main-navigation>ul>li:not(.selected) a", "pseudoEl" => ""];

--- a/lib/MBMigration/Builder/Layout/Theme/Dusk/Elements/Head.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Dusk/Elements/Head.php
@@ -206,6 +206,11 @@ class Head extends HeadElement
 
     }
 
+    public function getThemeMenuItemActiveSelector(): array
+    {
+        return ["selector" => "#main-navigation>ul>li.selected a", "pseudoEl" => ""];
+    }
+
     public function getThemeMenuItemSelector(): array
     {
         return ["selector" => "#main-navigation>ul>li:not(.selected) a", "pseudoEl" => ""];

--- a/lib/MBMigration/Builder/Layout/Theme/Ember/Elements/Head.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Ember/Elements/Head.php
@@ -80,6 +80,11 @@ class Head extends HeadElement
         return ["selector" => "#main-navigation>ul>li:not(.selected)>a", "pseudoEl" => ""];
     }
 
+    public function getThemeMenuItemActiveSelector(): array
+    {
+        return ["selector" => "#main-navigation>ul>li.selected a", "pseudoEl" => ""];
+    }
+
     public function getThemeParentMenuItemSelector(): array
     {
         return ["selector" => "#main-navigation ul li.has-sub", "pseudoEl" => ""];

--- a/lib/MBMigration/Builder/Layout/Theme/Hope/Elements/Head.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Hope/Elements/Head.php
@@ -211,6 +211,11 @@ class Head extends HeadElement
         return ["selector" => "#main-navigation>ul>li:not(.selected) a", "pseudoEl" => ""];
     }
 
+    public function getThemeMenuItemActiveSelector(): array
+    {
+        return ["selector" => "#main-navigation>ul>li.selected a", "pseudoEl" => ""];
+    }
+
     public function getThemeParentMenuItemSelector(): array
     {
         return ["selector" => "#main-navigation", "pseudoEl" => ""];

--- a/lib/MBMigration/Builder/Layout/Theme/Majesty/Elements/Head.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Majesty/Elements/Head.php
@@ -170,6 +170,11 @@ class Head extends HeadElement
         return ["selector" => "#main-navigation>ul>li:not(.selected) a", "pseudoEl" => ""];
     }
 
+    public function getThemeMenuItemActiveSelector(): array
+    {
+        return ["selector" => "#main-navigation>ul>li.selected a", "pseudoEl" => ""];
+    }
+
     public function getThemeParentMenuItemSelector(): array
     {
         return ["selector" => "#main-navigation>ul>li.has-sub>a", "pseudoEl" => ""];

--- a/lib/MBMigration/Builder/Layout/Theme/Serene/Elements/Head.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Serene/Elements/Head.php
@@ -206,6 +206,11 @@ class Head extends HeadElement
 
     }
 
+    public function getThemeMenuItemActiveSelector(): array
+    {
+        return ["selector" => "#main-navigation>ul>li.selected a", "pseudoEl" => ""];
+    }
+
     public function getThemeMenuItemSelector(): array
     {
         return ["selector" => "#main-navigation>ul>li:not(.selected) a", "pseudoEl" => ""];

--- a/lib/MBMigration/Builder/Layout/Theme/Solstice/Elements/Head.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Solstice/Elements/Head.php
@@ -25,6 +25,11 @@ class Head extends HeadElement
         return $brizySection->getItemWithDepth(0, 0, 1, 0, 0);
     }
 
+    public function getThemeMenuItemActiveSelector(): array
+    {
+        return ["selector" => "#main-navigation>ul>li.selected a", "pseudoEl" => ""];
+    }
+
     public function getThemeMenuItemSelector(): array
     {
         return ["selector" => "#main-navigation>ul>li:not(.selected)>a", "pseudoEl" => ""];

--- a/lib/MBMigration/Builder/Layout/Theme/Tradition/Elements/Head.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Tradition/Elements/Head.php
@@ -211,6 +211,11 @@ class Head extends HeadElement
         return ["selector" => "#main-navigation>ul>li:not(.selected) a", "pseudoEl" => ""];
     }
 
+    public function getThemeMenuItemActiveSelector(): array
+    {
+        return ["selector" => "#main-navigation>ul>li.selected a", "pseudoEl" => ""];
+    }
+
     public function getThemeParentMenuItemSelector(): array
     {
         return ["selector" => "#main-navigation", "pseudoEl" => ""];

--- a/lib/MBMigration/Builder/Layout/Theme/Voyage/Elements/Head.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Voyage/Elements/Head.php
@@ -97,6 +97,11 @@ class Head extends HeadElement
         return ["selector" => "#main-navigation>ul>li:not(.selected) a", "pseudoEl" => ""];
     }
 
+    public function getThemeMenuItemActiveSelector(): array
+    {
+        return ["selector" => "#main-navigation>ul>li.selected a", "pseudoEl" => ""];
+    }
+
     public function getThemeMobileBtnSelector(): array
     {
         return $this->getThemeMenuItemMobileSelector();

--- a/lib/MBMigration/Builder/Layout/Theme/Zion/Elements/Head.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Zion/Elements/Head.php
@@ -211,6 +211,11 @@ class Head extends HeadElement
         return ["selector" => "#main-navigation>ul>li:not(.selected) a", "pseudoEl" => ""];
     }
 
+    public function getThemeMenuItemActiveSelector(): array
+    {
+        return ["selector" => "#main-navigation>ul>li.selected a", "pseudoEl" => ""];
+    }
+
     public function getThemeParentMenuItemSelector(): array
     {
         return ["selector" => "#main-navigation", "pseudoEl" => ""];


### PR DESCRIPTION
Introduce `getThemeMenuItemActiveSelector` method across themes to define selectors for active menu items. This ensures consistency in handling active state styles and improves navigation functionality.