### PR TITLE
refactor: move browser page logic to Solstice Head element

### DIFF
--- a/lib/MBMigration/Builder/Layout/Common/Elements/AbstractElement.php
+++ b/lib/MBMigration/Builder/Layout/Common/Elements/AbstractElement.php
@@ -161,25 +161,12 @@ abstract class AbstractElement implements ElementInterface
 
     protected function beforeTransformToItem(ElementContextInterface $data): void
     {
-        $menuEnt = $data->getThemeContext()->getBrizyMenuEntity();
-        $deepSlug = PathSlugExtractor::findDeepestSlug($menuEnt['list']);
-        $menuUrl = PathSlugExtractor::getFullUrl($deepSlug['slug']);
-        $currentMigrateSlugPage = $data->getThemeContext()->getSlug();
-        $migrateUrl = PathSlugExtractor::getFullUrl($currentMigrateSlugPage);
-        $layoutName = $data->getThemeContext()->getLayoutName();
-        $browser = $data->getThemeContext()->getBrowser();
 
-        $this->browserPage = $browser->openPage($menuUrl, $layoutName);
     }
 
     protected function afterTransformToItem(BrizyComponent $brizySection): void
     {
-        $currentMigrateSlugPage = $this->themeContext->getSlug();
-        $migrateUrl = PathSlugExtractor::getFullUrl($currentMigrateSlugPage);
-        $layoutName = $this->themeContext->getLayoutName();
-        $browser = $this->themeContext->getBrowser();
 
-        $this->browserPage = $browser->openPage($migrateUrl, $layoutName);
     }
 
     protected function afterTransformTabs(BrizyComponent $brizySection): void

--- a/lib/MBMigration/Builder/Layout/Common/Elements/AbstractElement.php
+++ b/lib/MBMigration/Builder/Layout/Common/Elements/AbstractElement.php
@@ -161,12 +161,10 @@ abstract class AbstractElement implements ElementInterface
 
     protected function beforeTransformToItem(ElementContextInterface $data): void
     {
-
     }
 
     protected function afterTransformToItem(BrizyComponent $brizySection): void
     {
-
     }
 
     protected function afterTransformTabs(BrizyComponent $brizySection): void

--- a/lib/MBMigration/Builder/Layout/Theme/Solstice/Elements/Head.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Solstice/Elements/Head.php
@@ -3,7 +3,9 @@
 namespace MBMigration\Builder\Layout\Theme\Solstice\Elements;
 
 use MBMigration\Builder\BrizyComponent\BrizyComponent;
+use MBMigration\Builder\Layout\Common\ElementContextInterface;
 use MBMigration\Builder\Layout\Common\Elements\HeadElement;
+use MBMigration\Builder\Utils\PathSlugExtractor;
 
 class Head extends HeadElement
 {

--- a/lib/MBMigration/Builder/Layout/Theme/Solstice/Elements/Head.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Solstice/Elements/Head.php
@@ -25,6 +25,30 @@ class Head extends HeadElement
         return $brizySection->getItemWithDepth(0, 0, 1, 0, 0);
     }
 
+    protected function beforeTransformToItem(ElementContextInterface $data): void
+    {
+        $menuEnt = $data->getThemeContext()->getBrizyMenuEntity();
+        $deepSlug = PathSlugExtractor::findDeepestSlug($menuEnt['list']);
+        $menuUrl = PathSlugExtractor::getFullUrl($deepSlug['slug']);
+        $currentMigrateSlugPage = $data->getThemeContext()->getSlug();
+        $migrateUrl = PathSlugExtractor::getFullUrl($currentMigrateSlugPage);
+        $layoutName = $data->getThemeContext()->getLayoutName();
+        $browser = $data->getThemeContext()->getBrowser();
+
+        $this->browserPage = $browser->openPage($menuUrl, $layoutName);
+    }
+
+    protected function afterTransformToItem(BrizyComponent $brizySection): void
+    {
+        $currentMigrateSlugPage = $this->themeContext->getSlug();
+        $migrateUrl = PathSlugExtractor::getFullUrl($currentMigrateSlugPage);
+        $layoutName = $this->themeContext->getLayoutName();
+        $browser = $this->themeContext->getBrowser();
+
+        $this->browserPage = $browser->openPage($migrateUrl, $layoutName);
+    }
+
+
     public function getThemeMenuItemActiveSelector(): array
     {
         return ["selector" => "#main-navigation>ul>li.selected a", "pseudoEl" => ""];


### PR DESCRIPTION
Extracted browser page handling logic from AbstractElement to Solstice Head element only. This improves encapsulation by localizing logic specific to the Solstice theme and prevents unnecessary duplication.