### PR TITLE
Set mobile padding for accordion section in Anthem theme

### DIFF
--- a/lib/MBMigration/Builder/Layout/Theme/Anthem/Elements/Text/AccordionLayoutElement.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Anthem/Elements/Text/AccordionLayoutElement.php
@@ -150,6 +150,13 @@ class AccordionLayoutElement extends \MBMigration\Builder\Layout\Common\Elements
 
         $brizyAccordionComponent->set_items($brizyAccordionItems);
 
+        $brizySection->getItemWithDepth(0,1,0)
+            ->getValue()
+            ->set_mobilePaddingRight(10)
+            ->set_mobilePaddingRightSuffix('px')
+            ->set_mobilePaddingLeft(10)
+            ->set_mobilePaddingLeftSuffix('px');
+
         return $brizySection;
     }
 


### PR DESCRIPTION
Added left and right mobile padding with pixel suffixes to ensure consistent styling for accordion elements in the Anthem theme across mobile devices. This enhances the visual alignment and improves user experience on smaller screens.