### PR TITLE
Refactor menu item background selector methods.

### DIFF
--- a/lib/MBMigration/Builder/Layout/Common/Elements/HeadElement.php
+++ b/lib/MBMigration/Builder/Layout/Common/Elements/HeadElement.php
@@ -247,7 +247,7 @@ abstract class HeadElement extends AbstractElement
         $menuItemStyles = $this->browserPage->evaluateScript('brizy.getMenuItem', [
             'itemSelector' => $menuItemSelector,
             'itemActiveSelector' => $this->getThemeMenuItemActiveSelector(),
-            'itemBgSelector' => $this->getThemeMenuItemBgSelector(),
+            'itemBgSelector' => $this->getMenuItemBgSelector(),
             'itemPaddingSelector' => $this->getThemeMenuItemPaddingSelector(),
             'itemMobileSelector' => $itemMobileSelector,
             'itemMobileBtnSelector' => $this->getThemeMobileBtnSelector(),
@@ -257,10 +257,10 @@ abstract class HeadElement extends AbstractElement
             'hover' => false,
         ]);
 
-        if ($this->browserPage->triggerEvent('hover', $menuItemSelector['selector'])) {
+        if ($this->browserPage->triggerEvent('hover', $this->getNotSelectedMenuItemBgSelector()['selector'])) {
             $hoverMenuItemStyles = $this->browserPage->evaluateScript('brizy.getMenuItem', [
                 'itemSelector' => $menuItemSelector,
-                'itemBgSelector' => $this->getThemeSubMenuItemBGSelector(),
+                'itemBgSelector' => $this->getMenuHoverItemBgSelector(),
                 'itemPaddingSelector' => $this->getThemeMenuItemPaddingSelector(),
                 'families' => $families,
                 'defaultFamily' => $defaultFamilies,
@@ -433,9 +433,13 @@ abstract class HeadElement extends AbstractElement
 
     abstract public function getThemeSubMenuItemBGSelector(): array;
 
-    abstract public function getThemeMenuItemBgSelector(): array;
-
     abstract public function getThemeMenuItemPaddingSelector(): array;
 
     abstract public function getThemeMenuItemActiveSelector(): array;
+
+    abstract public function getNotSelectedMenuItemBgSelector(): array;
+
+    abstract public function getMenuItemBgSelector(): array;
+
+    abstract public function getMenuHoverItemBgSelector(): array;
 }

--- a/lib/MBMigration/Builder/Layout/Theme/Anthem/Elements/Head.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Anthem/Elements/Head.php
@@ -359,11 +359,6 @@ class Head extends HeadElement
         return ["selector" => "#mobile-nav-button-container", "pseudoEl" => ""];
     }
 
-    public function getThemeMenuItemBgSelector(): array
-    {
-        return $this->getThemeMenuItemSelector();
-    }
-
     protected function getPropertiesIconMenuItem(): array
     {
         return [
@@ -428,5 +423,20 @@ class Head extends HeadElement
             "activeMenuBorderBottomWidth" => 2,
             "activeMenuBorderLeftWidth" => 0,
         ];
+    }
+
+    public function getMenuItemBgSelector(): array
+    {
+        return $this->getThemeMenuItemSelector();
+    }
+
+    public function getMenuHoverItemBgSelector(): array
+    {
+        return $this->getThemeSubMenuItemBGSelector();
+    }
+
+    public function getNotSelectedMenuItemBgSelector(): array
+    {
+        return $this->getThemeMenuItemSelector();
     }
 }

--- a/lib/MBMigration/Builder/Layout/Theme/August/Elements/Head.php
+++ b/lib/MBMigration/Builder/Layout/Theme/August/Elements/Head.php
@@ -256,11 +256,6 @@ class Head extends HeadElement
         return ["selector" => "#mobile-nav-button-container", "pseudoEl" => ""];
     }
 
-    public function getThemeMenuItemBgSelector(): array
-    {
-        return $this->getThemeMenuItemSelector();
-    }
-
     protected function getPropertiesIconMenuItem(): array
     {
         return [
@@ -325,5 +320,20 @@ class Head extends HeadElement
             "activeMenuBorderBottomWidth" => 2,
             "activeMenuBorderLeftWidth" => 0,
         ];
+    }
+
+    public function getMenuItemBgSelector(): array
+    {
+        return $this->getThemeMenuItemSelector();
+    }
+
+    public function getMenuHoverItemBgSelector(): array
+    {
+        return $this->getThemeSubMenuItemBGSelector();
+    }
+
+    public function getNotSelectedMenuItemBgSelector(): array
+    {
+        return $this->getThemeMenuItemSelector();
     }
 }

--- a/lib/MBMigration/Builder/Layout/Theme/Aurora/Elements/Head.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Aurora/Elements/Head.php
@@ -269,10 +269,6 @@ class Head extends HeadElement
         return ["selector" => "#mobile-nav-button-container", "pseudoEl" => ""];
     }
 
-    public function getThemeMenuItemBgSelector(): array
-    {
-        return $this->getThemeMenuItemSelector();
-    }
     public function getPropertiesMainSection(): array
     {
         return [
@@ -359,5 +355,20 @@ class Head extends HeadElement
     protected function getThemeSubMenuItemSelector(): array
     {
         return ["selector" => "#selected-sub-navigation > ul > li > a", "pseudoEl" => ""];
+    }
+
+    public function getMenuItemBgSelector(): array
+    {
+        return $this->getThemeMenuItemSelector();
+    }
+
+    public function getMenuHoverItemBgSelector(): array
+    {
+        return $this->getThemeSubMenuItemBGSelector();
+    }
+
+    public function getNotSelectedMenuItemBgSelector(): array
+    {
+        return $this->getThemeMenuItemSelector();
     }
 }

--- a/lib/MBMigration/Builder/Layout/Theme/Bloom/Elements/Head.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Bloom/Elements/Head.php
@@ -63,11 +63,6 @@ class Head extends HeadElement
         return ["selector" => "#main-navigation ul li.has-sub ul.sub-navigation li", "className" => "selected"];
     }
 
-    public function getThemeMenuItemBgSelector(): array
-    {
-        return $this->getThemeMenuItemSelector();
-    }
-
     public function getThemeSubMenuItemBGSelector(): array
     {
         return ["selector" => "#main-navigation>ul>li.has-sub .sub-navigation", "pseudoEl" => ""];
@@ -267,5 +262,20 @@ class Head extends HeadElement
     public function getThemeSubMenuSelectedItemSelector(): array
     {
         return ["selector" => "#main-navigation ul li.has-sub ul.sub-navigation li.selected a", "pseudoEl" => ""];
+    }
+
+    public function getMenuItemBgSelector(): array
+    {
+        return $this->getThemeMenuItemSelector();
+    }
+
+    public function getMenuHoverItemBgSelector(): array
+    {
+        return $this->getThemeSubMenuItemBGSelector();
+    }
+
+    public function getNotSelectedMenuItemBgSelector(): array
+    {
+        return $this->getThemeMenuItemSelector();
     }
 }

--- a/lib/MBMigration/Builder/Layout/Theme/Boulevard/Elements/Head.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Boulevard/Elements/Head.php
@@ -256,11 +256,6 @@ class Head extends HeadElement
         return ["selector" => "#mobile-nav-button-container", "pseudoEl" => ""];
     }
 
-    public function getThemeMenuItemBgSelector(): array
-    {
-        return $this->getThemeMenuItemSelector();
-    }
-
     protected function getPropertiesIconMenuItem(): array
     {
         return [
@@ -325,5 +320,20 @@ class Head extends HeadElement
             "activeMenuBorderBottomWidth" => 2,
             "activeMenuBorderLeftWidth" => 0,
         ];
+    }
+
+    public function getMenuItemBgSelector(): array
+    {
+        return $this->getThemeMenuItemSelector();
+    }
+
+    public function getMenuHoverItemBgSelector(): array
+    {
+        return $this->getThemeSubMenuItemBGSelector();
+    }
+
+    public function getNotSelectedMenuItemBgSelector(): array
+    {
+        return $this->getThemeMenuItemSelector();
     }
 }

--- a/lib/MBMigration/Builder/Layout/Theme/Dusk/Elements/Head.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Dusk/Elements/Head.php
@@ -256,11 +256,6 @@ class Head extends HeadElement
         return ["selector" => "#mobile-nav-button-container", "pseudoEl" => ""];
     }
 
-    public function getThemeMenuItemBgSelector(): array
-    {
-        return $this->getThemeMenuItemSelector();
-    }
-
     protected function getPropertiesIconMenuItem(): array
     {
         return [
@@ -325,5 +320,20 @@ class Head extends HeadElement
             "activeMenuBorderBottomWidth" => 2,
             "activeMenuBorderLeftWidth" => 0,
         ];
+    }
+
+    public function getMenuItemBgSelector(): array
+    {
+        return $this->getThemeMenuItemSelector();
+    }
+
+    public function getMenuHoverItemBgSelector(): array
+    {
+        return $this->getThemeSubMenuItemBGSelector();
+    }
+
+    public function getNotSelectedMenuItemBgSelector(): array
+    {
+        return $this->getThemeMenuItemSelector();
     }
 }

--- a/lib/MBMigration/Builder/Layout/Theme/Ember/Elements/Head.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Ember/Elements/Head.php
@@ -105,11 +105,6 @@ class Head extends HeadElement
         return ["selector" => "#main-navigation ul li.has-sub ul.sub-navigation li", "className" => "selected"];
     }
 
-    public function getThemeMenuItemBgSelector(): array
-    {
-        return $this->getThemeMenuItemSelector();
-    }
-
     public function getThemeSubMenuItemBGSelector(): array
     {
         return $this->getThemeSubMenuNotSelectedItemSelector();
@@ -155,5 +150,20 @@ class Head extends HeadElement
     protected function getThemeSubMenuItemSelector(): array
     {
         return ["selector" => "#main-navigation ul li.has-sub ul.sub-navigation li a", "pseudoEl" => ""];
+    }
+
+    public function getMenuItemBgSelector(): array
+    {
+        return $this->getThemeMenuItemSelector();
+    }
+
+    public function getMenuHoverItemBgSelector(): array
+    {
+        return $this->getThemeSubMenuNotSelectedItemSelector();
+    }
+
+    public function getNotSelectedMenuItemBgSelector(): array
+    {
+        return $this->getThemeMenuItemSelector();
     }
 }

--- a/lib/MBMigration/Builder/Layout/Theme/Hope/Elements/Head.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Hope/Elements/Head.php
@@ -256,11 +256,6 @@ class Head extends HeadElement
         return ["selector" => "#mobile-nav-button-container", "pseudoEl" => ""];
     }
 
-    public function getThemeMenuItemBgSelector(): array
-    {
-        return $this->getThemeMenuItemSelector();
-    }
-
     protected function getPropertiesIconMenuItem(): array
     {
         return [
@@ -325,5 +320,20 @@ class Head extends HeadElement
             "activeMenuBorderBottomWidth" => 2,
             "activeMenuBorderLeftWidth" => 0,
         ];
+    }
+
+    public function getMenuItemBgSelector(): array
+    {
+        return $this->getThemeMenuItemSelector();
+    }
+
+    public function getMenuHoverItemBgSelector(): array
+    {
+        return $this->getThemeSubMenuItemBGSelector();
+    }
+
+    public function getNotSelectedMenuItemBgSelector(): array
+    {
+        return $this->getThemeMenuItemSelector();
     }
 }

--- a/lib/MBMigration/Builder/Layout/Theme/Majesty/Elements/Head.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Majesty/Elements/Head.php
@@ -215,11 +215,6 @@ class Head extends HeadElement
         return $this->getThemeMenuItemMobileSelector();
     }
 
-    public function getThemeMenuItemBgSelector(): array
-    {
-        return $this->getThemeMenuItemSelector();
-    }
-
     protected function getPropertiesIconMenuItem(): array
     {
         return [
@@ -283,5 +278,20 @@ class Head extends HeadElement
     protected function getThemeSubMenuItemSelector(): array
     {
         return ["selector" => "#main-navigation ul li.has-sub ul.sub-navigation li a", "pseudoEl" => ""];
+    }
+
+    public function getMenuItemBgSelector(): array
+    {
+        return $this->getThemeMenuItemSelector();
+    }
+
+    public function getMenuHoverItemBgSelector(): array
+    {
+        return $this->getThemeSubMenuItemBGSelector();
+    }
+
+    public function getNotSelectedMenuItemBgSelector(): array
+    {
+        return $this->getThemeMenuItemSelector();
     }
 }

--- a/lib/MBMigration/Builder/Layout/Theme/Serene/Elements/Head.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Serene/Elements/Head.php
@@ -256,11 +256,6 @@ class Head extends HeadElement
         return ["selector" => "#mobile-nav-button-container", "pseudoEl" => ""];
     }
 
-    public function getThemeMenuItemBgSelector(): array
-    {
-        return $this->getThemeMenuItemSelector();
-    }
-
     protected function getPropertiesIconMenuItem(): array
     {
         return [
@@ -325,5 +320,20 @@ class Head extends HeadElement
             "activeMenuBorderBottomWidth" => 2,
             "activeMenuBorderLeftWidth" => 0,
         ];
+    }
+
+    public function getMenuItemBgSelector(): array
+    {
+        return $this->getThemeMenuItemSelector();
+    }
+
+    public function getMenuHoverItemBgSelector(): array
+    {
+        return $this->getThemeSubMenuItemBGSelector();
+    }
+
+    public function getNotSelectedMenuItemBgSelector(): array
+    {
+        return $this->getThemeMenuItemSelector();
     }
 }

--- a/lib/MBMigration/Builder/Layout/Theme/Solstice/Elements/Head.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Solstice/Elements/Head.php
@@ -88,11 +88,6 @@ class Head extends HeadElement
         return ["selector" => "#main-navigation>ul>li.has-sub>ul>li.selected>a", "className" => "selected"];
     }
 
-    public function getThemeMenuItemBgSelector(): array
-    {
-        return $this->getThemeMenuItemSelector();
-    }
-
     public function getThemeSubMenuItemBGSelector(): array
     {
         return ["selector" => "#main-navigation>ul>li:has(.sub-navigation) .sub-navigation", "pseudoEl" => ""];
@@ -154,31 +149,25 @@ class Head extends HeadElement
             ->set_mobileMarginRight('25')
             ->set_tempMobileMarginRight('25');
 
-//        $section->getItemWithDepth(0, 0, 1, 0, 0)
-//            ->getValue()
-//            ->set_menuPaddingTop('10')
-//            ->set_menuPaddingTopSuffix('px')
-//            ->set_menuPaddingRight('15')
-//            ->set_menuPaddingRightSuffix('px')
-//            ->set_menuPaddingBottom('10')
-//            ->set_menuPaddingBottomSuffix('px')
-//            ->set_menuPaddingLeft('15')
-//            ->set_menuPaddingLeftSuffix('px')
-//            ->set_menuBorderRadius('50')
-//            ->set_menuBorderRadiusSuffix('px');
-//
-//        if (isset($headStyles['menu']['mMenuHoverColorHex'])) {
-//            $section->getItemWithDepth(0, 0, 1, 0, 0)
-//                ->getValue()
-//                ->set_hoverMenuBgColorHex($headStyles['menu']['mMenuHoverColorHex']);
-//        }
-//
-//        if (isset($headStyles['menu']['mMenuHoverColorOpacity'])) {
-//            $section->getItemWithDepth(0, 0, 1, 0, 0)
-//                ->getValue()
-//                ->set_hoverMenuBgColorOpacity($headStyles['menu']['mMenuHoverColorOpacity']);
-//        }
+        $section->getItemWithDepth(0,0,1,0,0)
+            ->getValue()
+            ->set_itemPadding('10');
 
         return $section;
+    }
+
+    public function getMenuItemBgSelector(): array
+    {
+        return ["selector" => "#main-navigation>ul>li:not(.selected) a span", "pseudoEl" => ""];
+    }
+
+    public function getMenuHoverItemBgSelector(): array
+    {
+        return $this->getMenuItemBgSelector();
+    }
+
+    public function getNotSelectedMenuItemBgSelector(): array
+    {
+        return ["selector" => "#main-navigation>ul>li:not(.selected)", "pseudoEl" => ""];
     }
 }

--- a/lib/MBMigration/Builder/Layout/Theme/Tradition/Elements/Head.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Tradition/Elements/Head.php
@@ -256,11 +256,6 @@ class Head extends HeadElement
         return ["selector" => "#mobile-nav-button-container", "pseudoEl" => ""];
     }
 
-    public function getThemeMenuItemBgSelector(): array
-    {
-        return $this->getThemeMenuItemSelector();
-    }
-
     protected function getPropertiesIconMenuItem(): array
     {
         return [
@@ -325,5 +320,20 @@ class Head extends HeadElement
             "activeMenuBorderBottomWidth" => 2,
             "activeMenuBorderLeftWidth" => 0,
         ];
+    }
+
+    public function getMenuItemBgSelector(): array
+    {
+        return $this->getThemeMenuItemSelector();
+    }
+
+    public function getMenuHoverItemBgSelector(): array
+    {
+        return $this->getThemeSubMenuItemBGSelector();
+    }
+
+    public function getNotSelectedMenuItemBgSelector(): array
+    {
+        return $this->getThemeMenuItemSelector();
     }
 }

--- a/lib/MBMigration/Builder/Layout/Theme/Voyage/Elements/Head.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Voyage/Elements/Head.php
@@ -132,11 +132,6 @@ class Head extends HeadElement
         return ["selector" => "#selected-sub-navigation ul li", "className" => "selected"];
     }
 
-    public function getThemeMenuItemBgSelector(): array
-    {
-        return $this->getThemeMenuItemSelector();
-    }
-
     public function getThemeSubMenuItemBGSelector(): array
     {
         return ["selector" => "#main-navigation ul li.has-sub .sub-navigation", "pseudoEl" => ":before"];
@@ -172,5 +167,20 @@ class Head extends HeadElement
     public function getThemeSubMenuSelectedItemSelector(): array
     {
         return ["selector" => "#main-navigation ul li.has-sub ul.sub-navigation li.selected a", "pseudoEl" => ""];
+    }
+
+    public function getMenuItemBgSelector(): array
+    {
+        return $this->getThemeMenuItemSelector();
+    }
+
+    public function getMenuHoverItemBgSelector(): array
+    {
+        return $this->getThemeSubMenuItemBGSelector();
+    }
+
+    public function getNotSelectedMenuItemBgSelector(): array
+    {
+        return $this->getThemeMenuItemSelector();
     }
 }

--- a/lib/MBMigration/Builder/Layout/Theme/Zion/Elements/Head.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Zion/Elements/Head.php
@@ -256,11 +256,6 @@ class Head extends HeadElement
         return ["selector" => "#mobile-nav-button-container", "pseudoEl" => ""];
     }
 
-    public function getThemeMenuItemBgSelector(): array
-    {
-        return $this->getThemeMenuItemSelector();
-    }
-
     protected function getPropertiesIconMenuItem(): array
     {
         return [
@@ -325,5 +320,20 @@ class Head extends HeadElement
             "activeMenuBorderBottomWidth" => 2,
             "activeMenuBorderLeftWidth" => 0,
         ];
+    }
+
+    public function getMenuItemBgSelector(): array
+    {
+        return $this->getThemeMenuItemSelector();
+    }
+
+    public function getMenuHoverItemBgSelector(): array
+    {
+        return $this->getThemeSubMenuItemBGSelector();
+    }
+
+    public function getNotSelectedMenuItemBgSelector(): array
+    {
+        return $this->getThemeMenuItemSelector();
     }
 }


### PR DESCRIPTION
Replaced `getThemeMenuItemBgSelector` with more specific methods: `getMenuItemBgSelector`, `getMenuHoverItemBgSelector`, and `getNotSelectedMenuItemBgSelector`. This improves code clarity and aligns with clearer method naming conventions. Updated associated logic in `HeadElement.php` to use the new methods.