### PR TITLE
Add hover menu style customization and `isBgHoverItemMenu` method

### DIFF
--- a/lib/MBMigration/Builder/Layout/Common/Elements/AbstractElement.php
+++ b/lib/MBMigration/Builder/Layout/Common/Elements/AbstractElement.php
@@ -191,6 +191,11 @@ abstract class AbstractElement implements ElementInterface
         return 'custom';
     }
 
+    public function isBgHoverItemMenu(): bool
+    {
+        return false;
+    }
+
 
     protected function getTopPaddingOfTheFirstElement(): int
     {

--- a/lib/MBMigration/Builder/Layout/Common/Elements/HeadElement.php
+++ b/lib/MBMigration/Builder/Layout/Common/Elements/HeadElement.php
@@ -258,14 +258,18 @@ abstract class HeadElement extends AbstractElement
         ]);
 
         if ($this->browserPage->triggerEvent('hover', $this->getNotSelectedMenuItemBgSelector()['selector'])) {
-            $hoverMenuItemStyles = $this->browserPage->evaluateScript('brizy.getMenuItem', [
+
+            $options = [
                 'itemSelector' => $menuItemSelector,
                 'itemBgSelector' => $this->getMenuHoverItemBgSelector(),
                 'itemPaddingSelector' => $this->getThemeMenuItemPaddingSelector(),
                 'families' => $families,
                 'defaultFamily' => $defaultFamilies,
                 'hover' => true,
-            ]);
+                'showHoverStyles' => $this->isBgHoverItemMenu()
+            ];
+
+            $hoverMenuItemStyles = $this->browserPage->evaluateScript('brizy.getMenuItem', $options);
         }
 
         return [

--- a/lib/MBMigration/Builder/Layout/Theme/Solstice/Elements/Head.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Solstice/Elements/Head.php
@@ -166,6 +166,11 @@ class Head extends HeadElement
         return $this->getMenuItemBgSelector();
     }
 
+    public function isBgHoverItemMenu(): bool
+    {
+        return true;
+    }
+
     public function getNotSelectedMenuItemBgSelector(): array
     {
         return ["selector" => "#main-navigation>ul>li:not(.selected)", "pseudoEl" => ""];


### PR DESCRIPTION
Enhanced hover menu styling by introducing the `isBgHoverItemMenu` method. Updated `evaluateScript` function to support additional hover style options for more flexible menu customization.