### PR TITLE
feat: add mobile padding properties for main section

### DIFF
--- a/lib/MBMigration/Builder/Layout/Theme/Majesty/Elements/Text/ThreeHorizontalText.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Majesty/Elements/Text/ThreeHorizontalText.php
@@ -60,9 +60,6 @@ class ThreeHorizontalText extends ThreeHorizontalTextElement
 
         }
 
-        $elementContext = $data->instanceWithBrizyComponent($brizySection->getItemWithDepth(0));
-        $this->handleSectionStyles($elementContext, $this->browserPage);
-
         return $brizySection;
     }
 
@@ -106,6 +103,23 @@ class ThreeHorizontalText extends ThreeHorizontalTextElement
         ksort($sortedItems);
 
         return $sortedItems;
+    }
+
+    protected function getPropertiesMainSection(): array
+    {
+        return [
+            "mobilePaddingType"=> "ungrouped",
+            "mobilePadding" => 0,
+            "mobilePaddingSuffix" => "px",
+            "mobilePaddingTop" => 25,
+            "mobilePaddingTopSuffix" => "px",
+            "mobilePaddingRight" => 20,
+            "mobilePaddingRightSuffix" => "px",
+            "mobilePaddingBottom" => 0,
+            "mobilePaddingBottomSuffix" => "px",
+            "mobilePaddingLeft" => 20,
+            "mobilePaddingLeftSuffix" => "px",
+        ];
     }
 
 }


### PR DESCRIPTION
Introduced `getPropertiesMainSection` method to define mobile padding properties for the main section. Removed unused code handling section styles, streamlining the implementation.