### PR TITLE
feat: add main section padding properties for mobile layout

### DIFF
--- a/lib/MBMigration/Builder/Layout/Theme/Majesty/Elements/Events/EventLayoutElement.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Majesty/Elements/Events/EventLayoutElement.php
@@ -14,7 +14,7 @@ class EventLayoutElement extends \MBMigration\Builder\Layout\Common\Elements\Eve
             "mobilePaddingTopSuffix" => "px",
             "mobilePaddingRight" => 20,
             "mobilePaddingRightSuffix" => "px",
-            "mobilePaddingBottom" => 0,
+            "mobilePaddingBottom" => 25,
             "mobilePaddingBottomSuffix" => "px",
             "mobilePaddingLeft" => 20,
             "mobilePaddingLeftSuffix" => "px",

--- a/lib/MBMigration/Builder/Layout/Theme/Majesty/Elements/Text/AccordionLayoutElement.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Majesty/Elements/Text/AccordionLayoutElement.php
@@ -174,4 +174,21 @@ class AccordionLayoutElement extends \MBMigration\Builder\Layout\Common\Elements
     {
         return 25;
     }
+
+    protected function getPropertiesMainSection(): array
+    {
+        return [
+            "mobilePaddingType"=> "ungrouped",
+            "mobilePadding" => 0,
+            "mobilePaddingSuffix" => "px",
+            "mobilePaddingTop" => 25,
+            "mobilePaddingTopSuffix" => "px",
+            "mobilePaddingRight" => 20,
+            "mobilePaddingRightSuffix" => "px",
+            "mobilePaddingBottom" => 25,
+            "mobilePaddingBottomSuffix" => "px",
+            "mobilePaddingLeft" => 20,
+            "mobilePaddingLeftSuffix" => "px",
+        ];
+    }
 }

--- a/lib/MBMigration/Builder/Layout/Theme/Majesty/Elements/Text/FullMediaElement.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Majesty/Elements/Text/FullMediaElement.php
@@ -35,4 +35,21 @@ class FullMediaElement extends FullMediaElementElement
     {
         return 25;
     }
+
+    protected function getPropertiesMainSection(): array
+    {
+        return [
+            "mobilePaddingType"=> "ungrouped",
+            "mobilePadding" => 0,
+            "mobilePaddingSuffix" => "px",
+            "mobilePaddingTop" => 25,
+            "mobilePaddingTopSuffix" => "px",
+            "mobilePaddingRight" => 20,
+            "mobilePaddingRightSuffix" => "px",
+            "mobilePaddingBottom" => 25,
+            "mobilePaddingBottomSuffix" => "px",
+            "mobilePaddingLeft" => 20,
+            "mobilePaddingLeftSuffix" => "px",
+        ];
+    }
 }

--- a/lib/MBMigration/Builder/Layout/Theme/Majesty/Elements/Text/FullText.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Majesty/Elements/Text/FullText.php
@@ -32,4 +32,21 @@ class FullText extends FullTextElement
     {
         return 25;
     }
+
+    protected function getPropertiesMainSection(): array
+    {
+        return [
+            "mobilePaddingType"=> "ungrouped",
+            "mobilePadding" => 0,
+            "mobilePaddingSuffix" => "px",
+            "mobilePaddingTop" => 25,
+            "mobilePaddingTopSuffix" => "px",
+            "mobilePaddingRight" => 20,
+            "mobilePaddingRightSuffix" => "px",
+            "mobilePaddingBottom" => 25,
+            "mobilePaddingBottomSuffix" => "px",
+            "mobilePaddingLeft" => 20,
+            "mobilePaddingLeftSuffix" => "px",
+        ];
+    }
 }

--- a/lib/MBMigration/Builder/Layout/Theme/Majesty/Elements/Text/LeftMedia.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Majesty/Elements/Text/LeftMedia.php
@@ -48,7 +48,7 @@ class LeftMedia extends PhotoTextElement
             "mobilePaddingTopSuffix" => "px",
             "mobilePaddingRight" => 20,
             "mobilePaddingRightSuffix" => "px",
-            "mobilePaddingBottom" => 0,
+            "mobilePaddingBottom" => 25,
             "mobilePaddingBottomSuffix" => "px",
             "mobilePaddingLeft" => 20,
             "mobilePaddingLeftSuffix" => "px",

--- a/lib/MBMigration/Builder/Layout/Theme/Majesty/Elements/Text/LeftMediaCircle.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Majesty/Elements/Text/LeftMediaCircle.php
@@ -40,7 +40,7 @@ class LeftMediaCircle extends PhotoTextElement
             "mobilePaddingTopSuffix" => "px",
             "mobilePaddingRight" => 20,
             "mobilePaddingRightSuffix" => "px",
-            "mobilePaddingBottom" => 0,
+            "mobilePaddingBottom" => 25,
             "mobilePaddingBottomSuffix" => "px",
             "mobilePaddingLeft" => 20,
             "mobilePaddingLeftSuffix" => "px",

--- a/lib/MBMigration/Builder/Layout/Theme/Majesty/Elements/Text/LeftMediaOverlap.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Majesty/Elements/Text/LeftMediaOverlap.php
@@ -65,4 +65,21 @@ class LeftMediaOverlap extends AbstractElement
         return $brizySection;
 
     }
+
+    protected function getPropertiesMainSection(): array
+    {
+        return [
+            "mobilePaddingType"=> "ungrouped",
+            "mobilePadding" => 0,
+            "mobilePaddingSuffix" => "px",
+            "mobilePaddingTop" => 25,
+            "mobilePaddingTopSuffix" => "px",
+            "mobilePaddingRight" => 20,
+            "mobilePaddingRightSuffix" => "px",
+            "mobilePaddingBottom" => 25,
+            "mobilePaddingBottomSuffix" => "px",
+            "mobilePaddingLeft" => 20,
+            "mobilePaddingLeftSuffix" => "px",
+        ];
+    }
 }

--- a/lib/MBMigration/Builder/Layout/Theme/Majesty/Elements/Text/ListLayoutElement.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Majesty/Elements/Text/ListLayoutElement.php
@@ -31,4 +31,21 @@ class ListLayoutElement extends \MBMigration\Builder\Layout\Common\Elements\Text
     {
         return $brizySection;
     }
+
+    protected function getPropertiesMainSection(): array
+    {
+        return [
+            "mobilePaddingType"=> "ungrouped",
+            "mobilePadding" => 0,
+            "mobilePaddingSuffix" => "px",
+            "mobilePaddingTop" => 25,
+            "mobilePaddingTopSuffix" => "px",
+            "mobilePaddingRight" => 20,
+            "mobilePaddingRightSuffix" => "px",
+            "mobilePaddingBottom" => 25,
+            "mobilePaddingBottomSuffix" => "px",
+            "mobilePaddingLeft" => 20,
+            "mobilePaddingLeftSuffix" => "px",
+        ];
+    }
 }

--- a/lib/MBMigration/Builder/Layout/Theme/Majesty/Elements/Text/RightMedia.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Majesty/Elements/Text/RightMedia.php
@@ -48,7 +48,7 @@ class RightMedia extends PhotoTextElement
             "mobilePaddingTopSuffix" => "px",
             "mobilePaddingRight" => 20,
             "mobilePaddingRightSuffix" => "px",
-            "mobilePaddingBottom" => 0,
+            "mobilePaddingBottom" => 25,
             "mobilePaddingBottomSuffix" => "px",
             "mobilePaddingLeft" => 20,
             "mobilePaddingLeftSuffix" => "px",

--- a/lib/MBMigration/Builder/Layout/Theme/Majesty/Elements/Text/RightMediaOverlap.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Majesty/Elements/Text/RightMediaOverlap.php
@@ -62,4 +62,21 @@ class RightMediaOverlap extends AbstractElement
         return $brizySection;
     }
 
+    protected function getPropertiesMainSection(): array
+    {
+        return [
+            "mobilePaddingType"=> "ungrouped",
+            "mobilePadding" => 0,
+            "mobilePaddingSuffix" => "px",
+            "mobilePaddingTop" => 25,
+            "mobilePaddingTopSuffix" => "px",
+            "mobilePaddingRight" => 20,
+            "mobilePaddingRightSuffix" => "px",
+            "mobilePaddingBottom" => 25,
+            "mobilePaddingBottomSuffix" => "px",
+            "mobilePaddingLeft" => 20,
+            "mobilePaddingLeftSuffix" => "px",
+        ];
+    }
+
 }

--- a/lib/MBMigration/Builder/Layout/Theme/Majesty/Elements/Text/TabsLayoutElement.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Majesty/Elements/Text/TabsLayoutElement.php
@@ -24,4 +24,21 @@ class TabsLayoutElement extends \MBMigration\Builder\Layout\Common\Elements\Text
         return $brizySection->getItemWithDepth(0, 1, 0, 0, 0);
     }
 
+    protected function getPropertiesMainSection(): array
+    {
+        return [
+            "mobilePaddingType"=> "ungrouped",
+            "mobilePadding" => 0,
+            "mobilePaddingSuffix" => "px",
+            "mobilePaddingTop" => 25,
+            "mobilePaddingTopSuffix" => "px",
+            "mobilePaddingRight" => 20,
+            "mobilePaddingRightSuffix" => "px",
+            "mobilePaddingBottom" => 25,
+            "mobilePaddingBottomSuffix" => "px",
+            "mobilePaddingLeft" => 20,
+            "mobilePaddingLeftSuffix" => "px",
+        ];
+    }
+
 }

--- a/lib/MBMigration/Builder/Layout/Theme/Majesty/Elements/Text/ThreeHorizontalText.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Majesty/Elements/Text/ThreeHorizontalText.php
@@ -115,7 +115,7 @@ class ThreeHorizontalText extends ThreeHorizontalTextElement
             "mobilePaddingTopSuffix" => "px",
             "mobilePaddingRight" => 20,
             "mobilePaddingRightSuffix" => "px",
-            "mobilePaddingBottom" => 0,
+            "mobilePaddingBottom" => 25,
             "mobilePaddingBottomSuffix" => "px",
             "mobilePaddingLeft" => 20,
             "mobilePaddingLeftSuffix" => "px",

--- a/lib/MBMigration/Builder/Layout/Theme/Majesty/Elements/Text/ThreeTopMediaCircle.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Majesty/Elements/Text/ThreeTopMediaCircle.php
@@ -31,4 +31,21 @@ class ThreeTopMediaCircle extends ThreeTopMediaCircleElement
     {
         return $brizySection->getItemWithDepth(0);
     }
+
+    protected function getPropertiesMainSection(): array
+    {
+        return [
+            "mobilePaddingType"=> "ungrouped",
+            "mobilePadding" => 0,
+            "mobilePaddingSuffix" => "px",
+            "mobilePaddingTop" => 25,
+            "mobilePaddingTopSuffix" => "px",
+            "mobilePaddingRight" => 20,
+            "mobilePaddingRightSuffix" => "px",
+            "mobilePaddingBottom" => 25,
+            "mobilePaddingBottomSuffix" => "px",
+            "mobilePaddingLeft" => 20,
+            "mobilePaddingLeftSuffix" => "px",
+        ];
+    }
 }

--- a/lib/MBMigration/Builder/Layout/Theme/Majesty/Elements/Text/ThreeTopMediaColumn.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Majesty/Elements/Text/ThreeTopMediaColumn.php
@@ -41,4 +41,21 @@ class ThreeTopMediaColumn extends ThreeTopMediaColumnElement
     {
         return $brizySection->getItemWithDepth(0);
     }
+
+    protected function getPropertiesMainSection(): array
+    {
+        return [
+            "mobilePaddingType"=> "ungrouped",
+            "mobilePadding" => 0,
+            "mobilePaddingSuffix" => "px",
+            "mobilePaddingTop" => 25,
+            "mobilePaddingTopSuffix" => "px",
+            "mobilePaddingRight" => 20,
+            "mobilePaddingRightSuffix" => "px",
+            "mobilePaddingBottom" => 25,
+            "mobilePaddingBottomSuffix" => "px",
+            "mobilePaddingLeft" => 20,
+            "mobilePaddingLeftSuffix" => "px",
+        ];
+    }
 }

--- a/lib/MBMigration/Builder/Layout/Theme/Majesty/Elements/Text/TwoRightMediaCircle.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Majesty/Elements/Text/TwoRightMediaCircle.php
@@ -93,7 +93,7 @@ class TwoRightMediaCircle extends PhotoTextElement
             "mobilePaddingTopSuffix" => "px",
             "mobilePaddingRight" => 20,
             "mobilePaddingRightSuffix" => "px",
-            "mobilePaddingBottom" => 0,
+            "mobilePaddingBottom" => 25,
             "mobilePaddingBottomSuffix" => "px",
             "mobilePaddingLeft" => 20,
             "mobilePaddingLeftSuffix" => "px",

--- a/lib/MBMigration/Builder/Layout/Theme/Solstice/Elements/Text/AccordionLayoutElement.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Solstice/Elements/Text/AccordionLayoutElement.php
@@ -15,4 +15,21 @@ class AccordionLayoutElement extends \MBMigration\Builder\Layout\Common\Elements
     {
         return $brizySection->getItemWithDepth(0, 1, 0, 0, 0);
     }
+
+    protected function getPropertiesMainSection(): array
+    {
+        return [
+            "mobilePaddingType"=> "ungrouped",
+            "mobilePadding" => 0,
+            "mobilePaddingSuffix" => "px",
+            "mobilePaddingTop" => 25,
+            "mobilePaddingTopSuffix" => "px",
+            "mobilePaddingRight" => 20,
+            "mobilePaddingRightSuffix" => "px",
+            "mobilePaddingBottom" => 25,
+            "mobilePaddingBottomSuffix" => "px",
+            "mobilePaddingLeft" => 20,
+            "mobilePaddingLeftSuffix" => "px",
+        ];
+    }
 }

--- a/lib/MBMigration/Builder/Layout/Theme/Solstice/Elements/Text/FourHorizontalText.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Solstice/Elements/Text/FourHorizontalText.php
@@ -51,4 +51,21 @@ class FourHorizontalText extends AbstractElement
 
         return $brizySection;
     }
+
+    protected function getPropertiesMainSection(): array
+    {
+        return [
+            "mobilePaddingType"=> "ungrouped",
+            "mobilePadding" => 0,
+            "mobilePaddingSuffix" => "px",
+            "mobilePaddingTop" => 25,
+            "mobilePaddingTopSuffix" => "px",
+            "mobilePaddingRight" => 20,
+            "mobilePaddingRightSuffix" => "px",
+            "mobilePaddingBottom" => 25,
+            "mobilePaddingBottomSuffix" => "px",
+            "mobilePaddingLeft" => 20,
+            "mobilePaddingLeftSuffix" => "px",
+        ];
+    }
 }

--- a/lib/MBMigration/Builder/Layout/Theme/Solstice/Elements/Text/FullMediaElement.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Solstice/Elements/Text/FullMediaElement.php
@@ -102,7 +102,7 @@ class FullMediaElement extends FullMediaElementElement
             "mobilePaddingTopSuffix" => "px",
             "mobilePaddingRight" => 20,
             "mobilePaddingRightSuffix" => "px",
-            "mobilePaddingBottom" => 0,
+            "mobilePaddingBottom" => 25,
             "mobilePaddingBottomSuffix" => "px",
             "mobilePaddingLeft" => 20,
             "mobilePaddingLeftSuffix" => "px",

--- a/lib/MBMigration/Builder/Layout/Theme/Solstice/Elements/Text/FullText.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Solstice/Elements/Text/FullText.php
@@ -26,4 +26,21 @@ class FullText extends FullTextElement
     {
         return 25;
     }
+
+    protected function getPropertiesMainSection(): array
+    {
+        return [
+            "mobilePaddingType"=> "ungrouped",
+            "mobilePadding" => 0,
+            "mobilePaddingSuffix" => "px",
+            "mobilePaddingTop" => 25,
+            "mobilePaddingTopSuffix" => "px",
+            "mobilePaddingRight" => 20,
+            "mobilePaddingRightSuffix" => "px",
+            "mobilePaddingBottom" => 25,
+            "mobilePaddingBottomSuffix" => "px",
+            "mobilePaddingLeft" => 20,
+            "mobilePaddingLeftSuffix" => "px",
+        ];
+    }
 }

--- a/lib/MBMigration/Builder/Layout/Theme/Solstice/Elements/Text/LeftMediaCircle.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Solstice/Elements/Text/LeftMediaCircle.php
@@ -40,7 +40,7 @@ class LeftMediaCircle extends PhotoTextElement
             "mobilePaddingTopSuffix" => "px",
             "mobilePaddingRight" => 20,
             "mobilePaddingRightSuffix" => "px",
-            "mobilePaddingBottom" => 0,
+            "mobilePaddingBottom" => 25,
             "mobilePaddingBottomSuffix" => "px",
             "mobilePaddingLeft" => 20,
             "mobilePaddingLeftSuffix" => "px",

--- a/lib/MBMigration/Builder/Layout/Theme/Solstice/Elements/Text/LeftMediaOverlap.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Solstice/Elements/Text/LeftMediaOverlap.php
@@ -57,4 +57,21 @@ class LeftMediaOverlap extends AbstractElement
         return $brizySection;
 
     }
+
+    protected function getPropertiesMainSection(): array
+    {
+        return [
+            "mobilePaddingType"=> "ungrouped",
+            "mobilePadding" => 0,
+            "mobilePaddingSuffix" => "px",
+            "mobilePaddingTop" => 25,
+            "mobilePaddingTopSuffix" => "px",
+            "mobilePaddingRight" => 20,
+            "mobilePaddingRightSuffix" => "px",
+            "mobilePaddingBottom" => 25,
+            "mobilePaddingBottomSuffix" => "px",
+            "mobilePaddingLeft" => 20,
+            "mobilePaddingLeftSuffix" => "px",
+        ];
+    }
 }

--- a/lib/MBMigration/Builder/Layout/Theme/Solstice/Elements/Text/ListLayoutElement.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Solstice/Elements/Text/ListLayoutElement.php
@@ -35,4 +35,21 @@ class ListLayoutElement extends \MBMigration\Builder\Layout\Common\Elements\Text
     {
         return $brizySection;
     }
+
+    protected function getPropertiesMainSection(): array
+    {
+        return [
+            "mobilePaddingType"=> "ungrouped",
+            "mobilePadding" => 0,
+            "mobilePaddingSuffix" => "px",
+            "mobilePaddingTop" => 25,
+            "mobilePaddingTopSuffix" => "px",
+            "mobilePaddingRight" => 20,
+            "mobilePaddingRightSuffix" => "px",
+            "mobilePaddingBottom" => 25,
+            "mobilePaddingBottomSuffix" => "px",
+            "mobilePaddingLeft" => 20,
+            "mobilePaddingLeftSuffix" => "px",
+        ];
+    }
 }

--- a/lib/MBMigration/Builder/Layout/Theme/Solstice/Elements/Text/RightMediaOverlap.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Solstice/Elements/Text/RightMediaOverlap.php
@@ -60,4 +60,21 @@ class RightMediaOverlap extends AbstractElement
         return $brizySection;
     }
 
+    protected function getPropertiesMainSection(): array
+    {
+        return [
+            "mobilePaddingType"=> "ungrouped",
+            "mobilePadding" => 0,
+            "mobilePaddingSuffix" => "px",
+            "mobilePaddingTop" => 25,
+            "mobilePaddingTopSuffix" => "px",
+            "mobilePaddingRight" => 20,
+            "mobilePaddingRightSuffix" => "px",
+            "mobilePaddingBottom" => 25,
+            "mobilePaddingBottomSuffix" => "px",
+            "mobilePaddingLeft" => 20,
+            "mobilePaddingLeftSuffix" => "px",
+        ];
+    }
+
 }

--- a/lib/MBMigration/Builder/Layout/Theme/Solstice/Elements/Text/TabsLayoutElement.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Solstice/Elements/Text/TabsLayoutElement.php
@@ -24,4 +24,21 @@ class TabsLayoutElement extends \MBMigration\Builder\Layout\Common\Elements\Text
         return $brizySection->getItemWithDepth(0, 1, 0, 0, 0);
     }
 
+    protected function getPropertiesMainSection(): array
+    {
+        return [
+            "mobilePaddingType"=> "ungrouped",
+            "mobilePadding" => 0,
+            "mobilePaddingSuffix" => "px",
+            "mobilePaddingTop" => 25,
+            "mobilePaddingTopSuffix" => "px",
+            "mobilePaddingRight" => 20,
+            "mobilePaddingRightSuffix" => "px",
+            "mobilePaddingBottom" => 25,
+            "mobilePaddingBottomSuffix" => "px",
+            "mobilePaddingLeft" => 20,
+            "mobilePaddingLeftSuffix" => "px",
+        ];
+    }
+
 }

--- a/lib/MBMigration/Builder/Layout/Theme/Solstice/Elements/Text/ThreeBottomMediaCircle.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Solstice/Elements/Text/ThreeBottomMediaCircle.php
@@ -42,4 +42,21 @@ class ThreeBottomMediaCircle extends FullTextElement
             ->set_imageFileName($mbSectionItem['imageFileName'])
             ->set_imageSrc($mbSectionItem['content']);
     }
+
+    protected function getPropertiesMainSection(): array
+    {
+        return [
+            "mobilePaddingType"=> "ungrouped",
+            "mobilePadding" => 0,
+            "mobilePaddingSuffix" => "px",
+            "mobilePaddingTop" => 25,
+            "mobilePaddingTopSuffix" => "px",
+            "mobilePaddingRight" => 20,
+            "mobilePaddingRightSuffix" => "px",
+            "mobilePaddingBottom" => 25,
+            "mobilePaddingBottomSuffix" => "px",
+            "mobilePaddingLeft" => 20,
+            "mobilePaddingLeftSuffix" => "px",
+        ];
+    }
 }

--- a/lib/MBMigration/Builder/Layout/Theme/Solstice/Elements/Text/ThreeTopMedia.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Solstice/Elements/Text/ThreeTopMedia.php
@@ -138,4 +138,21 @@ class ThreeTopMedia extends Element
         }
     }
 
+    protected function getPropertiesMainSection(): array
+    {
+        return [
+            "mobilePaddingType"=> "ungrouped",
+            "mobilePadding" => 0,
+            "mobilePaddingSuffix" => "px",
+            "mobilePaddingTop" => 25,
+            "mobilePaddingTopSuffix" => "px",
+            "mobilePaddingRight" => 20,
+            "mobilePaddingRightSuffix" => "px",
+            "mobilePaddingBottom" => 25,
+            "mobilePaddingBottomSuffix" => "px",
+            "mobilePaddingLeft" => 20,
+            "mobilePaddingLeftSuffix" => "px",
+        ];
+    }
+
 }

--- a/lib/MBMigration/Builder/Layout/Theme/Solstice/Elements/Text/TopMedia.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Solstice/Elements/Text/TopMedia.php
@@ -115,4 +115,21 @@ class TopMedia extends Element
             }
         }
     }
+
+    protected function getPropertiesMainSection(): array
+    {
+        return [
+            "mobilePaddingType"=> "ungrouped",
+            "mobilePadding" => 0,
+            "mobilePaddingSuffix" => "px",
+            "mobilePaddingTop" => 25,
+            "mobilePaddingTopSuffix" => "px",
+            "mobilePaddingRight" => 20,
+            "mobilePaddingRightSuffix" => "px",
+            "mobilePaddingBottom" => 25,
+            "mobilePaddingBottomSuffix" => "px",
+            "mobilePaddingLeft" => 20,
+            "mobilePaddingLeftSuffix" => "px",
+        ];
+    }
 }


### PR DESCRIPTION
Introduced `getPropertiesMainSection` method to define consistent mobile padding settings across layouts. Updated bottom padding where necessary to maintain visual alignment.