### PR TITLE
fix: update logo sizing to use original dimensions

### DIFF
--- a/lib/MBMigration/Builder/Layout/Theme/Majesty/Elements/Head.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Majesty/Elements/Head.php
@@ -81,7 +81,7 @@ class Head extends HeadElement
             ->set_mobileBgColorOpacity($headStyle['bg-opacity']);
 
         $imageLogoOptions = [
-            'sizeType' => 'custom',
+            'sizeType' => 'original',
 
             'imageWidth' => $headStyle['image-width'],
             'imageHeight' => $headStyle['image-height'],
@@ -90,6 +90,9 @@ class Head extends HeadElement
             'width' => 300,
             'widthSuffix' => 'px',
             'heightSuffix' => '%',
+
+            'size' => 40,
+            'sizeSuffix' => '%',
 
             'mobileSize' => 52,
             'mobileSizeSuffix' => '%',


### PR DESCRIPTION
Changed logo sizeType from "custom" to "original" for correct scaling. Added additional size-related properties to improve layout rendering consistency.