### PR TITLE
feat: add font customization support for donation buttons

### DIFF
--- a/lib/MBMigration/Builder/BrizyComponent/BrizyComponent.php
+++ b/lib/MBMigration/Builder/BrizyComponent/BrizyComponent.php
@@ -504,6 +504,29 @@ class BrizyComponent implements JsonSerializable
         return $this;
     }
 
+    public function addFont($fontSize, $fontFamily, $fontFamilyType): BrizyComponent
+    {
+        $bgColor = [
+            "fontStyle" => "",
+            "fontFamily" => $fontFamily,
+            "fontFamilyType" => $fontFamilyType,
+            "fontSize" => $fontSize,
+            "fontSizeSuffix" => "px",
+            "fontWeight" => 700,
+            "letterSpacing" => 0,
+            "lineHeight" => 1.6,
+            "variableFontWeight" => 400,
+            "fontWidth" => 100,
+            "fontSoftness" => 0
+        ];
+
+        foreach ($bgColor as $key => $value) {
+            $this->getValue()->set($key, $value);
+        }
+
+        return $this;
+    }
+
     public function previewTypography($typography = []): BrizyComponent
     {
         $bgColor = [

--- a/lib/MBMigration/Builder/Layout/Common/Concern/DonationsAble.php
+++ b/lib/MBMigration/Builder/Layout/Common/Concern/DonationsAble.php
@@ -9,6 +9,7 @@ use MBMigration\Builder\Layout\Common\ElementContextInterface;
 use MBMigration\Builder\Layout\Common\Exception\BrizyKitNotFound;
 use MBMigration\Builder\Layout\Common\Exception\BrowserScriptException;
 use MBMigration\Builder\Utils\ColorConverter;
+use MBMigration\Builder\Utils\FontUtils;
 use MBMigration\Core\Logger;
 
 trait DonationsAble
@@ -292,6 +293,28 @@ trait DonationsAble
             ->set_colorHex(ColorConverter::rgba2hex($buttonStyles['color']))
             ->set_colorOpacity(ColorConverter::rgba2opacity($buttonStyles['color']))
             ->set_colorPalette("");
+
+
+        $fontList = $data->getFontFamilies();
+
+        if($font =$fontList[FontUtils::transliterateFontFamily($buttonStyles['font-family'])])
+        {
+            $butonFont = [
+                'fontFamily' => $font['name'],
+                'fontFamilyType' => $font['type'],
+            ];
+        }else{
+            $butonFont = [
+                'fontFamily' => "lato",
+                'fontFamilyType' => "google",
+            ];
+        }
+
+        $brizyDonationButton->getItemWithDepth(0)->addFont(
+            (int) $buttonStyles['font-size'],
+            $butonFont['fontFamily'],
+            $butonFont['fontFamilyType'],
+        );
 
         return $brizyDonationButton;
     }


### PR DESCRIPTION
Introduced logic to handle font family, type, and size for donation buttons using `FontUtils` and `addFont`. This ensures proper font rendering and defaults to Lato if no match is found.