### PR TITLE
Add `targetImageSize` method for flexible image size configuration

### DIFF
--- a/lib/MBMigration/Builder/Layout/Theme/Majesty/Elements/Text/LeftMedia.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Majesty/Elements/Text/LeftMedia.php
@@ -19,6 +19,17 @@ class LeftMedia extends PhotoTextElement
         return $brizySection->getItemWithDepth(0, 0, 0, 0, 0);
     }
 
+    public function targetImageSize(BrizyComponent $imageTarget, int $width, int $height){
+        $imageTarget
+            ->getValue()
+            ->set_width($width)
+            ->set_height($height)
+            ->set_mobileSize(100)
+            ->set_mobileSizeSuffix('%')
+            ->set_heightSuffix((strpos($height,'%')===true)?'%':'px')
+            ->set_widthSuffix((strpos($width,'%')===true)?'%':'px');
+    }
+
     /**
      * @param BrizyComponent $brizySection
      * @return mixed|null

--- a/lib/MBMigration/Builder/Layout/Theme/Majesty/Elements/Text/RightMedia.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Majesty/Elements/Text/RightMedia.php
@@ -19,6 +19,17 @@ class RightMedia extends PhotoTextElement
         return $brizySection->getItemWithDepth(0, 0, 1, 0,0);
     }
 
+    public function targetImageSize(BrizyComponent $imageTarget, int $width, int $height){
+        $imageTarget
+            ->getValue()
+            ->set_width($width)
+            ->set_height($height)
+            ->set_mobileSize(100)
+            ->set_mobileSizeSuffix('%')
+            ->set_heightSuffix((strpos($height,'%')===true)?'%':'px')
+            ->set_widthSuffix((strpos($width,'%')===true)?'%':'px');
+    }
+
     /**
      * @param BrizyComponent $brizySection
      * @return mixed|null


### PR DESCRIPTION
Introduced the `targetImageSize` method in `LeftMedia` and `RightMedia` classes to allow dynamic setting of image width, height, and mobile size suffixes, enhancing media element customization.