### PR TITLE
feat: add default height type handle to MediaLayoutElement

### DIFF
--- a/lib/MBMigration/Builder/Layout/Theme/Majesty/Elements/Sermons/MediaLayoutElement.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Majesty/Elements/Sermons/MediaLayoutElement.php
@@ -3,6 +3,13 @@ namespace MBMigration\Builder\Layout\Theme\Majesty\Elements\Sermons;
 
 class MediaLayoutElement extends \MBMigration\Builder\Layout\Common\Elements\Sermons\MediaLayoutElement
 {
+
+    protected function getHeightTypeHandleSectionStyles(): string
+    {
+        // default option custom
+        // auto/custom/full
+        return 'auto';
+    }
     protected function getPropertiesMainSection(): array
     {
         return [


### PR DESCRIPTION
Introduce a new method `getHeightTypeHandleSectionStyles` returning a default value of 'auto'. This enhances flexibility in handling height type styles for the media layout element.