### PR TITLE
feat: improved page handling

### DIFF
--- a/lib/MBMigration/Builder/Layout/Common/MenuBuilder.php
+++ b/lib/MBMigration/Builder/Layout/Common/MenuBuilder.php
@@ -86,6 +86,7 @@ class MenuBuilder implements MenuBuilderInterface
 
         $newItem = [
             "uid" => Utils::getNameHash(),
+            "mbPageId" => $item['id'],
             "isNewTab" => $this->checkOpenInNewTab($settings),
             'isIndex'=>$item['position']==1 && !$item['parent_id'] && $item['landing'],
             "label" => TextTools::transformText($item['name'], $textTransformMenu),

--- a/lib/MBMigration/Builder/Menu/MenuHandler.php
+++ b/lib/MBMigration/Builder/Menu/MenuHandler.php
@@ -26,9 +26,9 @@ class MenuHandler
     public function __construct(BrowserPagePHP $browserPage)
     {
         $this->cache = VariableCache::getInstance();
-        
+
         $this->browserPage = $browserPage;
-        
+
         $this->brizyApi = $this->cache->getClass('brizyApi');
         $this->projectID_Brizy = $this->cache->get('projectId_Brizy');
     }


### PR DESCRIPTION
Introduced the `launch_bld` method to handle pages based on menu items and their associated settings. This enhances the flexibility of page processing during migrations. Also added a `mbPageId` field to the menu item structure for better tracking.