### PR TITLE
fix: update color contrast logic and enhance submenu dropdown selector

### DIFF
--- a/lib/MBMigration/Builder/Layout/Common/Elements/Gallery/GalleryLayoutElement.php
+++ b/lib/MBMigration/Builder/Layout/Common/Elements/Gallery/GalleryLayoutElement.php
@@ -67,7 +67,7 @@ abstract class GalleryLayoutElement extends AbstractElement
 //            $transitionDuration = (float)$mbSection['settings']['sections']['gallery']['transition_duration'] ?? 0.1;
 //        }
 
-        $colorArrows = ColorConverter::getContrastColor($properties['background-color'] ?? '#FFFFFF');
+        $colorArrows = ColorConverter::getContrastColor($properties['background-color']);
 
         $brizySection->getValue()
             ->set_sliderArrowsColorHex($colorArrows)

--- a/lib/MBMigration/Builder/Layout/Theme/Solstice/Elements/Head.php
+++ b/lib/MBMigration/Builder/Layout/Theme/Solstice/Elements/Head.php
@@ -202,5 +202,10 @@ class Head extends HeadElement
     {
         return ["selector" => "#main-navigation>ul>li:not(.selected)", "pseudoEl" => ""];
     }
+
+    protected function getThemeSubMenuItemDropDownSelector(): array
+    {
+        return ["selector" => "#main-navigation > ul > li.has-sub > ul", "pseudoEl" => ""];
+    }
 }
 

--- a/lib/MBMigration/Builder/Utils/ColorConverter.php
+++ b/lib/MBMigration/Builder/Utils/ColorConverter.php
@@ -222,17 +222,33 @@ final class ColorConverter
         return $inputString;
     }
 
-    public static function getContrastColor($hexColor): string
-    {
-        $hexColor = str_replace('#', '', $hexColor);
+    public static function getContrastColor(
+        string $hexColor
+    ): string {
+        $luminosityThreshold = 0.9;
+        $hexColor            = strtoupper(ltrim($hexColor, '#'));
 
-        $r = hexdec(substr($hexColor, 0, 2));
-        $g = hexdec(substr($hexColor, 2, 2));
-        $b = hexdec(substr($hexColor, 4, 2));
+        if (!preg_match('/^[0-9A-F]{3}$|^[0-9A-F]{6}$/', $hexColor)) {
+            return "#FFFFFF";
+        }
 
-        $brightness = (($r * 299) + ($g * 587) + ($b * 114)) / 1000;
+        if (strlen($hexColor) === 3) {
+            $red   = hexdec($hexColor[0].$hexColor[0]);
+            $green = hexdec($hexColor[1].$hexColor[1]);
+            $blue  = hexdec($hexColor[2].$hexColor[2]);
+        } else {
+            $red   = hexdec(substr($hexColor, 0, 2));
+            $green = hexdec(substr($hexColor, 2, 2));
+            $blue  = hexdec(substr($hexColor, 4, 2));
+        }
 
-        return $brightness > 125 ? '#000000' : '#FFFFFF';
+        $luminosity = (($red + $green + $blue) / 3) / 255.0;
+
+        if ($luminosity >= $luminosityThreshold) {
+            return "#000000";
+        } else {
+            return "#FFFFFF";
+        }
     }
 
     public static function getHoverOpacity(float $baseOpacity): float {


### PR DESCRIPTION
Refactored the `getContrastColor` method in `ColorConverter` to improve color handling and added a new method for fetching submenu dropdown selectors in the `Head` class. These changes enhance the accuracy of color contrast calculations and improve the maintainability of submenu styles.